### PR TITLE
Issue #30 - docs: add description to Advisor API readme

### DIFF
--- a/projects/lif_advisor_api/README.md
+++ b/projects/lif_advisor_api/README.md
@@ -1,7 +1,7 @@
 # Advisor AI
 
 The **Advisor API** facilitates a conversational experience by authenticating users, managing session states,
-and interacting with a language model agent to provide personalized chat interactions.
+and interacting with a language model agent to provide personalized chat interactions using the user's LIF data as context.
 
 # Example usage
 


### PR DESCRIPTION
There was no design doc for this component.