### PR TITLE
Issue #47: Adjust sequences in sql scripts

### DIFF
--- a/projects/lif_mdr_database/backup.sql
+++ b/projects/lif_mdr_database/backup.sql
@@ -18218,7 +18218,7 @@ COPY public."ValueSets" ("Id", "Name", "Description", "UseConsiderations", "Data
 -- Name: Attributes_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Attributes_Id_seq"', 1954, true);
+SELECT pg_catalog.setval('public."Attributes_Id_seq"', 1955, true);
 
 
 --
@@ -18239,14 +18239,14 @@ SELECT pg_catalog.setval('public."DataModelConstraints_Id_seq"', 1, false);
 -- Name: DataModels_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."DataModels_Id_seq"', 26, true);
+SELECT pg_catalog.setval('public."DataModels_Id_seq"', 27, true);
 
 
 --
 -- Name: Entities_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Entities_Id_seq"', 378, true);
+SELECT pg_catalog.setval('public."Entities_Id_seq"', 379, true);
 
 
 --
@@ -18260,14 +18260,14 @@ SELECT pg_catalog.setval('public."EntityAssociation_Id_seq"', 185, true);
 -- Name: EntityAttributeAssociation_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."EntityAttributeAssociation_Id_seq"', 2224, true);
+SELECT pg_catalog.setval('public."EntityAttributeAssociation_Id_seq"', 2225, true);
 
 
 --
 -- Name: ExtInclusionsFromBaseDM_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."ExtInclusionsFromBaseDM_Id_seq"', 378, true);
+SELECT pg_catalog.setval('public."ExtInclusionsFromBaseDM_Id_seq"', 379, true);
 
 
 --
@@ -18281,21 +18281,21 @@ SELECT pg_catalog.setval('public."ExtMappedValueSet_Id_seq"', 1, false);
 -- Name: TransformationAttributes_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2727, true);
+SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2743, true);
 
 
 --
 -- Name: TransformationsGroup_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."TransformationsGroup_Id_seq"', 26, true);
+SELECT pg_catalog.setval('public."TransformationsGroup_Id_seq"', 27, true);
 
 
 --
 -- Name: Transformations_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1370, true);
+SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1373, true);
 
 
 --
@@ -18316,7 +18316,7 @@ SELECT pg_catalog.setval('public."ValueSetValues_Id_seq"', 5346, true);
 -- Name: ValueSets_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."ValueSets_Id_seq"', 364, true);
+SELECT pg_catalog.setval('public."ValueSets_Id_seq"', 365, true);
 
 
 --

--- a/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.1__metadata_repository_init.sql
+++ b/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.1__metadata_repository_init.sql
@@ -18218,7 +18218,7 @@ COPY public."ValueSets" ("Id", "Name", "Description", "UseConsiderations", "Data
 -- Name: Attributes_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Attributes_Id_seq"', 1954, true);
+SELECT pg_catalog.setval('public."Attributes_Id_seq"', 1955, true);
 
 
 --
@@ -18239,14 +18239,14 @@ SELECT pg_catalog.setval('public."DataModelConstraints_Id_seq"', 1, false);
 -- Name: DataModels_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."DataModels_Id_seq"', 26, true);
+SELECT pg_catalog.setval('public."DataModels_Id_seq"', 27, true);
 
 
 --
 -- Name: Entities_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Entities_Id_seq"', 378, true);
+SELECT pg_catalog.setval('public."Entities_Id_seq"', 379, true);
 
 
 --
@@ -18260,14 +18260,14 @@ SELECT pg_catalog.setval('public."EntityAssociation_Id_seq"', 185, true);
 -- Name: EntityAttributeAssociation_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."EntityAttributeAssociation_Id_seq"', 2224, true);
+SELECT pg_catalog.setval('public."EntityAttributeAssociation_Id_seq"', 2225, true);
 
 
 --
 -- Name: ExtInclusionsFromBaseDM_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."ExtInclusionsFromBaseDM_Id_seq"', 378, true);
+SELECT pg_catalog.setval('public."ExtInclusionsFromBaseDM_Id_seq"', 379, true);
 
 
 --
@@ -18281,21 +18281,21 @@ SELECT pg_catalog.setval('public."ExtMappedValueSet_Id_seq"', 1, false);
 -- Name: TransformationAttributes_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2727, true);
+SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2743, true);
 
 
 --
 -- Name: TransformationsGroup_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."TransformationsGroup_Id_seq"', 26, true);
+SELECT pg_catalog.setval('public."TransformationsGroup_Id_seq"', 27, true);
 
 
 --
 -- Name: Transformations_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1370, true);
+SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1373, true);
 
 
 --
@@ -18316,7 +18316,7 @@ SELECT pg_catalog.setval('public."ValueSetValues_Id_seq"', 5346, true);
 -- Name: ValueSets_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."ValueSets_Id_seq"', 364, true);
+SELECT pg_catalog.setval('public."ValueSets_Id_seq"', 365, true);
 
 
 --


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] all tests are successful
- [x] code passes linting checks (`uv run ruff check`)
- [x] code passes formatting checks (`uv run ruff format`)
- [x] code passes type checking (`uv run ty check`)
- [x] pre-commit hooks have been run successfully

##### Type of Change
<!-- Check all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure/deployment change

##### Description of Change
Adjusts the sequences of the database to be 1 greater than the last used ID for each given table. Technically we may not have had to bump up sequences that were even with the last used IDs, but just to be on the safe side...

##### Related Issues

Closes #47

##### Testing

- [x] Manual testing performed

##### Project Area(s) Affected

- [x] deployments/
- [x] CloudFormation/SAM templates

##### Additional Notes
Confirmed the sequences are equal to the table IDs or +1 in the hosted dev and demo sites, so while this updates the migration file for consistency, we don't need to run a migration.
