### PR TITLE
833: Convert legacy entityIdPaths to the new CSV version

### DIFF
--- a/projects/lif_mdr_database/backup.sql
+++ b/projects/lif_mdr_database/backup.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
-\restrict TGXcobvEDSI6TGDeZoAETI9vJfNNbpxKZKvt1sIrFyHvwg7Qt8hwlkiNcCGsIjY
+\restrict zx3zIkeT4b37a7IAXsl16N94tUClHXnAXZaBrvz3JVKfqa3fXHJMM8SAcc6f62u
 
--- Dumped from database version 17.6 (Debian 17.6-1.pgdg13+1)
--- Dumped by pg_dump version 17.6 (Homebrew)
+-- Dumped from database version 18.1 (Debian 18.1-1.pgdg13+2)
+-- Dumped by pg_dump version 18.1 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -8544,7 +8544,6 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2677	1841	1340	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	\N	\N
 2678	1834	1341	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	\N	\N
 2679	1833	1341	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	\N	\N
-2704	1833	1350	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	342	TestOrgEntity
 2694	1834	1340	Source	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	340	\N
 2695	1839	1340	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	354	\N
 2696	1841	1340	Target	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	349	\N
@@ -8560,21 +8559,9 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2681	1833	1342	Target	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	\N
 2689	1839	1342	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	354	\N
 2690	1834	1342	Source	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	340	\N
-2701	1851	1349	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	340.341
-2702	1833	1349	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	342	342
 2691	1834	1343	Source	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	340	\N
 2692	1833	1343	Target	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	\N
 2693	1839	1343	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	354	\N
-2716	1042	1360	Source	\N	\N	\N	\N	\N	\N	f	f	\N	179	Alignment
-2703	1851	1350	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2717	1816	1360	Target	\N	\N	\N	\N	\N	\N	f	f	\N	134	Person.CredentialAward
-2710	1851	1357	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2712	1851	1358	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2714	1851	1359	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2718	1741	1361	Source	\N	\N	\N	\N	\N	\N	f	f	\N	331	OpenBadgeCredential
-2719	833	1361	Target	\N	\N	\N	\N	\N	\N	f	f	\N	134	Person.CredentialAward
-2720	1777	1362	Source	\N	\N	\N	\N	\N	\N	f	f	\N	325	achievement.creator
-2721	1200	1362	Target	\N	\N	\N	\N	\N	\N	f	f	\N	212	Person.CredentialAward.issuerOrganization
 2713	1815	1358	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	212	Person.CredentialAward.issuerOrganization
 2715	1815	1359	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	212	Person.CredentialAward.issuerOrganization
 2711	1815	1357	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	212	Person.CredentialAward.issuerOrganization
@@ -8636,6 +8623,15 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2674	1824	1339	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2590	841	1297	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2591	1761	1297	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
+2720	1777	1362	Source	\N	\N	\N	\N	\N	\N	t	f	\N	325	achievement.creator
+2721	1200	1362	Target	\N	\N	\N	\N	\N	\N	t	f	\N	212	Person.CredentialAward.issuerOrganization
+2716	1042	1360	Source	\N	\N	\N	\N	\N	\N	t	f	\N	179	Alignment
+2717	1816	1360	Target	\N	\N	\N	\N	\N	\N	t	f	\N	134	Person.CredentialAward
+2701	1851	1349	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	340.341
+2703	1851	1350	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
+2710	1851	1357	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
+2712	1851	1358	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
+2714	1851	1359	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
 2594	842	1299	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2595	1763	1299	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2592	843	1298	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
@@ -8698,8 +8694,6 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2585	1757	1294	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2648	1290	1326	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2649	1791	1326	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
-2726	1895	1365	Source	\N	\N	\N	\N	\N	\N	f	f	\N	377	person.employment.preferences
-2727	1876	1365	Target	\N	\N	\N	\N	\N	\N	f	f	\N	359	Person.EmploymentPreferences
 2724	1895	1364	Source	\N	\N	\N	\N	\N	\N	t	f	\N	377	person.employment.preferences
 2725	1876	1364	Target	\N	\N	\N	\N	\N	\N	t	f	\N	359	Person.employmentPreferences
 2722	1422	1363	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
@@ -8710,8 +8704,6 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2731	1311	1367	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
 2728	1423	1366	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
 2729	1309	1366	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
-2734	1422	1369	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	AddressType
-2735	1307	1369	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	Person.Contact.Address
 2738	1425	1371	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
 2739	1311	1371	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
 2740	1424	1372	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
@@ -8719,6 +8711,26 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2736	1423	1370	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
 2737	1309	1370	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
 2742	1426	1370	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
+2718	1741	1361	Source	\N	\N	\N	\N	\N	\N	t	f	\N	331	OpenBadgeCredential
+2719	833	1361	Target	\N	\N	\N	\N	\N	\N	t	f	\N	134	Person.CredentialAward
+2744	1894	1374	Source	\N	\N	\N	\N	\N	\N	t	f	\N	375	375,-1894
+2745	2	1374	Target	\N	\N	\N	\N	\N	\N	t	f	\N	1	1,-2
+2734	1422	1369	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
+2735	1307	1369	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
+2746	1422	1375	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1422
+2747	1307	1375	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1307
+2748	1423	1376	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1423
+2749	1309	1376	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1309
+2750	1425	1377	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1425
+2751	1311	1377	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1311
+2752	1426	1378	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1426
+2753	1313	1378	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1313
+2726	1895	1365	Source	\N	\N	\N	\N	\N	\N	t	f	\N	377	person.employment.preferences
+2727	1876	1365	Target	\N	\N	\N	\N	\N	\N	t	f	\N	359	Person.EmploymentPreferences
+2754	1895	1379	Source	\N	\N	\N	\N	\N	\N	f	f	\N	377	375,376,377,-1895
+2704	1833	1350	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	TestOrgEntity
+2755	1876	1379	Target	\N	\N	\N	\N	\N	\N	f	f	\N	359	4,359,-1876
+2702	1833	1349	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	342
 \.
 
 
@@ -10049,11 +10061,7 @@ COPY public."Transformations" ("Id", "TransformationGroupId", "Name", "Descripti
 1271	10	Program.Educational\nOccupational\nProgram.identifier	\N	\N	Intent	\N	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	LIF	t	f	\N
 1273	10	Program.Course.numberOfCredits	\N	\N	Reworded	\N	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	LIF	t	f	\N
 1277	10	Program.Course.about	\N	\N	Reworded	\N	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	LIF	t	f	\N
-1358	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1359	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1360	23	Person.CredentialAward.term	\N	\N	\N	{ "Person": Alignment. { "CredentialAward": [{ "term": targetDescription }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
-1361	16	Person.CredentialAward.id	\N	\N	\N	{ "Person": OpenBadgeCredential. { "CredentialAward": [{ "id": id }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
-1362	16	Person.CredentialAward.issuerOrganization.name	\N	\N	\N	{ "Person": achievement. { "CredentialAward": [{ "issuerOrganization": [{ "name": creator.name }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1359	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1342	18	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute + Update	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1341	18	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1343	18	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute + Update	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
@@ -10063,15 +10071,6 @@ COPY public."Transformations" ("Id", "TransformationGroupId", "Name", "Descripti
 1346	21	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1347	21	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1348	21	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
-1349	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1350	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1351	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1352	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1353	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1354	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1355	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1356	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1357	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
 1324	16	address.credentialSubject.achievement.creator.address.geo.latitude	\N	\N	\N	Organization.Contact[n].Address[n].latitude = OpenBadgeCredential.credentialSubject.achievement.creator.address.geo.latitude	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1325	16	address.credentialSubject.achievement.creator.address.geo.longitude	\N	\N	\N	Organization.Contact[n].Address[n].longitude = OpenBadgeCredential.credentialSubject.achievement.creator.address.geo.longitude	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1312	16	creator.url	\N	\N	\N	Organization.Contact[n].websiteAddress = OpenBadgeCredential.credentialSubject.achievement.creator.url	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
@@ -10090,15 +10089,34 @@ COPY public."Transformations" ("Id", "TransformationGroupId", "Name", "Descripti
 1339	16	refreshService.type	\N	\N	\N	Person.CredentialAward.refreshServiceType = OpenBadgeCredential.refreshService.type	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1328	16	creator.official	\N	\N	\N	Organization.credentialOfficial = OpenBadgeCredential.credentialSubject.achievement.creator.official	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1364	26	Person.employmentPreferences.organizationTypes	\N	\N	\N	person.employmentPreferences[].organizationTypes = person.employment.preferences.preferred_org_types	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
-1365	26	Person.EmploymentPreferences.organizationTypes	\N	\N	\N	{ "person": [{ "employmentPreferences": [{ "organizationTypes": person.employment.preferences.preferred_org_types }] }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1362	16	Person.CredentialAward.issuerOrganization.name	\N	\N	\N	{ "Person": achievement. { "CredentialAward": [{ "issuerOrganization": [{ "name": creator.name }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1360	23	Person.CredentialAward.term	\N	\N	\N	{ "Person": Alignment. { "CredentialAward": [{ "term": targetDescription }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1349	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1350	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1351	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1353	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1354	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1355	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1356	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1357	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1363	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1368	25	Person.Contact.Address.countryCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "countryCode": countryCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1367	25	Person.Contact.Address.addressPostalCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressPostalCode": postalCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1366	25	Person.Contact.Address.addressCity	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressCity": city }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
-1369	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
 1371	25	Person.Contact.Address.addressPostalCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressPostalCode": postalCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1372	25	Person.Contact.Address.addressLine2	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressLine2": countrySubDivisions }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1370	25	Person.Contact.Address.addressCity	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressCity": city }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1361	16	Person.CredentialAward.id	\N	\N	\N	{ "Person": OpenBadgeCredential. { "CredentialAward": [{ "id": id }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1374	26	Assessment.identifier	\N	\N	\N	{ "Assessment": [{ "identifier": person.id }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1369	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1375	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1376	25	Person.Contact.Address.addressCity	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressCity": city }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1377	25	Person.Contact.Address.addressPostalCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressPostalCode": postalCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1378	25	Person.Contact.Address.countryCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "countryCode": countryCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1365	26	Person.EmploymentPreferences.organizationTypes	\N	\N	\N	{ "person": [{ "employmentPreferences": [{ "organizationTypes": person.employment.preferences.preferred_org_types }] }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1379	26	Person.EmploymentPreferences.organizationTypes	\N	\N	\N	{ "Person": [{ "EmploymentPreferences": [{ "organizationTypes": person.employment.preferences.preferred_org_types }] }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1352	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1358	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 \.
 
 
@@ -18515,6 +18533,7 @@ CREATE UNIQUE INDEX ux_valuesets_name_datamodelid_active ON public."ValueSets" U
 
 CREATE UNIQUE INDEX ux_valuesetvalues_valuename_valuesetid_active ON public."ValueSetValues" USING btree ("ValueName", "ValueSetId") WHERE ("Deleted" IS NOT TRUE);
 
+
 --
 -- Name: ValueSetValueMapping FK_ValueSetValueMapping_SourceValueSet; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -18743,5 +18762,5 @@ ALTER TABLE ONLY public."TransformationAttributes"
 -- PostgreSQL database dump complete
 --
 
-\unrestrict TGXcobvEDSI6TGDeZoAETI9vJfNNbpxKZKvt1sIrFyHvwg7Qt8hwlkiNcCGsIjY
+\unrestrict zx3zIkeT4b37a7IAXsl16N94tUClHXnAXZaBrvz3JVKfqa3fXHJMM8SAcc6f62u
 

--- a/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.1__metadata_repository_init.sql
+++ b/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.1__metadata_repository_init.sql
@@ -2,10 +2,10 @@
 -- PostgreSQL database dump
 --
 
--- \restrict TGXcobvEDSI6TGDeZoAETI9vJfNNbpxKZKvt1sIrFyHvwg7Qt8hwlkiNcCGsIjY
+-- \restrict zx3zIkeT4b37a7IAXsl16N94tUClHXnAXZaBrvz3JVKfqa3fXHJMM8SAcc6f62u
 
--- Dumped from database version 17.6 (Debian 17.6-1.pgdg13+1)
--- Dumped by pg_dump version 17.6 (Homebrew)
+-- Dumped from database version 18.1 (Debian 18.1-1.pgdg13+2)
+-- Dumped by pg_dump version 18.1 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -3234,7 +3234,7 @@ COPY public."EntityAssociation" ("Id", "ParentEntityId", "ChildEntityId", "Relat
 19	129	132	\N	\N	\N	\N	\N	\N	\N	LIF	f	f	\N	\N
 20	129	133	\N	\N	\N	\N	\N	\N	\N	LIF	f	f	\N	\N
 91	129	304	aligned	Reference	\N	\N	\N	\N	\N	LIF	f	f	\N	\N
-95	134	129	instanceOf	Reference	Specification of the Credential	\N	\N	\N	\N	LIF	f	f	\N	\N
+95	134	129	InstanceOf	Reference	Specification of the Credential	\N	\N	\N	\N	LIF	f	f	\N	\N
 18	130	131	\N	\N	\N	\N	\N	\N	\N	LIF	f	f	\N	\N
 22	134	135	\N	\N	\N	\N	\N	\N	\N	LIF	f	f	\N	\N
 23	134	136	\N	\N	\N	\N	\N	\N	\N	LIF	f	f	\N	\N
@@ -8544,7 +8544,6 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2677	1841	1340	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	\N	\N
 2678	1834	1341	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	\N	\N
 2679	1833	1341	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	\N	\N
-2704	1833	1350	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	342	TestOrgEntity
 2694	1834	1340	Source	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	340	\N
 2695	1839	1340	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	354	\N
 2696	1841	1340	Target	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	349	\N
@@ -8560,21 +8559,9 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2681	1833	1342	Target	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	\N
 2689	1839	1342	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	354	\N
 2690	1834	1342	Source	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	340	\N
-2701	1851	1349	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	340.341
-2702	1833	1349	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	342	342
 2691	1834	1343	Source	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	340	\N
 2692	1833	1343	Target	Updated	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	\N
 2693	1839	1343	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	354	\N
-2716	1042	1360	Source	\N	\N	\N	\N	\N	\N	f	f	\N	179	Alignment
-2703	1851	1350	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2717	1816	1360	Target	\N	\N	\N	\N	\N	\N	f	f	\N	134	Person.CredentialAward
-2710	1851	1357	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2712	1851	1358	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2714	1851	1359	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
-2718	1741	1361	Source	\N	\N	\N	\N	\N	\N	f	f	\N	331	OpenBadgeCredential
-2719	833	1361	Target	\N	\N	\N	\N	\N	\N	f	f	\N	134	Person.CredentialAward
-2720	1777	1362	Source	\N	\N	\N	\N	\N	\N	f	f	\N	325	achievement.creator
-2721	1200	1362	Target	\N	\N	\N	\N	\N	\N	f	f	\N	212	Person.CredentialAward.issuerOrganization
 2713	1815	1358	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	212	Person.CredentialAward.issuerOrganization
 2715	1815	1359	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	212	Person.CredentialAward.issuerOrganization
 2711	1815	1357	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	212	Person.CredentialAward.issuerOrganization
@@ -8636,6 +8623,15 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2674	1824	1339	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2590	841	1297	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2591	1761	1297	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
+2720	1777	1362	Source	\N	\N	\N	\N	\N	\N	t	f	\N	325	achievement.creator
+2721	1200	1362	Target	\N	\N	\N	\N	\N	\N	t	f	\N	212	Person.CredentialAward.issuerOrganization
+2716	1042	1360	Source	\N	\N	\N	\N	\N	\N	t	f	\N	179	Alignment
+2717	1816	1360	Target	\N	\N	\N	\N	\N	\N	t	f	\N	134	Person.CredentialAward
+2701	1851	1349	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	340.341
+2703	1851	1350	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
+2710	1851	1357	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
+2712	1851	1358	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
+2714	1851	1359	Source	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	341	TestNewSourceEntity.TestChildSourceEntity
 2594	842	1299	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2595	1763	1299	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2592	843	1298	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
@@ -8698,8 +8694,6 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2585	1757	1294	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2648	1290	1326	Target	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
 2649	1791	1326	Source	\N	\N	\N	\N	\N	StateU	t	f	\N	\N	\N
-2726	1895	1365	Source	\N	\N	\N	\N	\N	\N	f	f	\N	377	person.employment.preferences
-2727	1876	1365	Target	\N	\N	\N	\N	\N	\N	f	f	\N	359	Person.EmploymentPreferences
 2724	1895	1364	Source	\N	\N	\N	\N	\N	\N	t	f	\N	377	person.employment.preferences
 2725	1876	1364	Target	\N	\N	\N	\N	\N	\N	t	f	\N	359	Person.employmentPreferences
 2722	1422	1363	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
@@ -8710,8 +8704,6 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2731	1311	1367	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
 2728	1423	1366	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
 2729	1309	1366	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
-2734	1422	1369	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	AddressType
-2735	1307	1369	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	Person.Contact.Address
 2738	1425	1371	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
 2739	1311	1371	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
 2740	1424	1372	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
@@ -8719,6 +8711,26 @@ COPY public."TransformationAttributes" ("Id", "AttributeId", "TransformationId",
 2736	1423	1370	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
 2737	1309	1370	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
 2742	1426	1370	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
+2718	1741	1361	Source	\N	\N	\N	\N	\N	\N	t	f	\N	331	OpenBadgeCredential
+2719	833	1361	Target	\N	\N	\N	\N	\N	\N	t	f	\N	134	Person.CredentialAward
+2744	1894	1374	Source	\N	\N	\N	\N	\N	\N	t	f	\N	375	375,-1894
+2745	2	1374	Target	\N	\N	\N	\N	\N	\N	t	f	\N	1	1,-2
+2734	1422	1369	Source	\N	\N	\N	\N	\N	\N	t	f	\N	255	AddressType
+2735	1307	1369	Target	\N	\N	\N	\N	\N	\N	t	f	\N	239	Person.Contact.Address
+2746	1422	1375	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1422
+2747	1307	1375	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1307
+2748	1423	1376	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1423
+2749	1309	1376	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1309
+2750	1425	1377	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1425
+2751	1311	1377	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1311
+2752	1426	1378	Source	\N	\N	\N	\N	\N	\N	f	f	\N	255	255,-1426
+2753	1313	1378	Target	\N	\N	\N	\N	\N	\N	f	f	\N	239	4,241,239,-1313
+2726	1895	1365	Source	\N	\N	\N	\N	\N	\N	t	f	\N	377	person.employment.preferences
+2727	1876	1365	Target	\N	\N	\N	\N	\N	\N	t	f	\N	359	Person.EmploymentPreferences
+2754	1895	1379	Source	\N	\N	\N	\N	\N	\N	f	f	\N	377	375,376,377,-1895
+2704	1833	1350	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	TestOrgEntity
+2755	1876	1379	Target	\N	\N	\N	\N	\N	\N	f	f	\N	359	4,359,-1876
+2702	1833	1349	Target	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N	342	342
 \.
 
 
@@ -10049,11 +10061,7 @@ COPY public."Transformations" ("Id", "TransformationGroupId", "Name", "Descripti
 1271	10	Program.Educational\nOccupational\nProgram.identifier	\N	\N	Intent	\N	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	LIF	t	f	\N
 1273	10	Program.Course.numberOfCredits	\N	\N	Reworded	\N	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	LIF	t	f	\N
 1277	10	Program.Course.about	\N	\N	Reworded	\N	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	LIF	t	f	\N
-1358	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1359	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1360	23	Person.CredentialAward.term	\N	\N	\N	{ "Person": Alignment. { "CredentialAward": [{ "term": targetDescription }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
-1361	16	Person.CredentialAward.id	\N	\N	\N	{ "Person": OpenBadgeCredential. { "CredentialAward": [{ "id": id }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
-1362	16	Person.CredentialAward.issuerOrganization.name	\N	\N	\N	{ "Person": achievement. { "CredentialAward": [{ "issuerOrganization": [{ "name": creator.name }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1359	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1342	18	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute + Update	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1341	18	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1343	18	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute + Update	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
@@ -10063,15 +10071,6 @@ COPY public."Transformations" ("Id", "TransformationGroupId", "Name", "Descripti
 1346	21	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1347	21	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1348	21	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
-1349	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1350	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1351	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1352	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1353	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1354	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1355	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1356	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
-1357	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	f	f	\N
 1324	16	address.credentialSubject.achievement.creator.address.geo.latitude	\N	\N	\N	Organization.Contact[n].Address[n].latitude = OpenBadgeCredential.credentialSubject.achievement.creator.address.geo.latitude	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1325	16	address.credentialSubject.achievement.creator.address.geo.longitude	\N	\N	\N	Organization.Contact[n].Address[n].longitude = OpenBadgeCredential.credentialSubject.achievement.creator.address.geo.longitude	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1312	16	creator.url	\N	\N	\N	Organization.Contact[n].websiteAddress = OpenBadgeCredential.credentialSubject.achievement.creator.url	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
@@ -10090,15 +10089,34 @@ COPY public."Transformations" ("Id", "TransformationGroupId", "Name", "Descripti
 1339	16	refreshService.type	\N	\N	\N	Person.CredentialAward.refreshServiceType = OpenBadgeCredential.refreshService.type	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1328	16	creator.official	\N	\N	\N	Organization.credentialOfficial = OpenBadgeCredential.credentialSubject.achievement.creator.official	LIF_Pseudo_Code	\N	\N	\N	\N	\N	\N	\N	StateU	t	f	\N
 1364	26	Person.employmentPreferences.organizationTypes	\N	\N	\N	person.employmentPreferences[].organizationTypes = person.employment.preferences.preferred_org_types	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
-1365	26	Person.EmploymentPreferences.organizationTypes	\N	\N	\N	{ "person": [{ "employmentPreferences": [{ "organizationTypes": person.employment.preferences.preferred_org_types }] }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1362	16	Person.CredentialAward.issuerOrganization.name	\N	\N	\N	{ "Person": achievement. { "CredentialAward": [{ "issuerOrganization": [{ "name": creator.name }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1360	23	Person.CredentialAward.term	\N	\N	\N	{ "Person": Alignment. { "CredentialAward": [{ "term": targetDescription }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1349	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1350	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1351	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1353	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1354	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1355	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1356	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1357	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 1363	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1368	25	Person.Contact.Address.countryCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "countryCode": countryCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1367	25	Person.Contact.Address.addressPostalCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressPostalCode": postalCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1366	25	Person.Contact.Address.addressCity	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressCity": city }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
-1369	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
 1371	25	Person.Contact.Address.addressPostalCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressPostalCode": postalCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1372	25	Person.Contact.Address.addressLine2	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressLine2": countrySubDivisions }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
 1370	25	Person.Contact.Address.addressCity	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressCity": city }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1361	16	Person.CredentialAward.id	\N	\N	\N	{ "Person": OpenBadgeCredential. { "CredentialAward": [{ "id": id }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1374	26	Assessment.identifier	\N	\N	\N	{ "Assessment": [{ "identifier": person.id }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1369	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1375	25	Person.Contact.Address.addressStreet	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressStreet": line }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1376	25	Person.Contact.Address.addressCity	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressCity": city }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1377	25	Person.Contact.Address.addressPostalCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "addressPostalCode": postalCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1378	25	Person.Contact.Address.countryCode	\N	\N	\N	{ "Person": AddressType. { "Contact": [{ "Address": [{ "countryCode": countryCode }] }] } }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1365	26	Person.EmploymentPreferences.organizationTypes	\N	\N	\N	{ "person": [{ "employmentPreferences": [{ "organizationTypes": person.employment.preferences.preferred_org_types }] }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	t	f	\N
+1379	26	Person.EmploymentPreferences.organizationTypes	\N	\N	\N	{ "Person": [{ "EmploymentPreferences": [{ "organizationTypes": person.employment.preferences.preferred_org_types }] }] }	JSONata	\N	\N	\N	\N	\N	\N	\N	\N	f	f	\N
+1352	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
+1358	22	TestOrgEntity.TestNewOrgAttribute	\N	\N	\N	TestOrgEntity.TestNewOrgAttribute = TestNewSourceEntity.TestNewSourceAttribute	JSONata	\N	\N	\N	2025-08-26 16:59:03.522+00	2025-08-26 16:59:03.522+00	\N	Mary Gwozdz	Unicon	t	f	\N
 \.
 
 
@@ -18744,5 +18762,5 @@ ALTER TABLE ONLY public."TransformationAttributes"
 -- PostgreSQL database dump complete
 --
 
--- \unrestrict TGXcobvEDSI6TGDeZoAETI9vJfNNbpxKZKvt1sIrFyHvwg7Qt8hwlkiNcCGsIjY
+-- \unrestrict zx3zIkeT4b37a7IAXsl16N94tUClHXnAXZaBrvz3JVKfqa3fXHJMM8SAcc6f62u
 


### PR DESCRIPTION
##### Description of Change
Convert legacy entityIdPaths to the new CSV version by using the MDR UI to remove any transformations that used the legacy entityIDPaths and, where needed, recreate the transformation.

##### Related Issues
#833 

Closes # [[add Github issue number]]
#833 

##### Type of Change
<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/deployment change
- [ ] Performance improvement
- [ ] Code refactoring
