### PR TITLE
Issue #833: adjust sequence generators

### DIFF
--- a/projects/lif_mdr_database/backup.sql
+++ b/projects/lif_mdr_database/backup.sql
@@ -18299,7 +18299,7 @@ SELECT pg_catalog.setval('public."ExtMappedValueSet_Id_seq"', 1, false);
 -- Name: TransformationAttributes_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2743, true);
+SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2756, true);
 
 
 --
@@ -18313,7 +18313,7 @@ SELECT pg_catalog.setval('public."TransformationsGroup_Id_seq"', 27, true);
 -- Name: Transformations_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1373, true);
+SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1380, true);
 
 
 --

--- a/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.1__metadata_repository_init.sql
+++ b/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.1__metadata_repository_init.sql
@@ -18299,7 +18299,7 @@ SELECT pg_catalog.setval('public."ExtMappedValueSet_Id_seq"', 1, false);
 -- Name: TransformationAttributes_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2743, true);
+SELECT pg_catalog.setval('public."TransformationAttributes_Id_seq"', 2756, true);
 
 
 --
@@ -18313,7 +18313,7 @@ SELECT pg_catalog.setval('public."TransformationsGroup_Id_seq"', 27, true);
 -- Name: Transformations_Id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
 --
 
-SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1373, true);
+SELECT pg_catalog.setval('public."Transformations_Id_seq"', 1380, true);
 
 
 --


### PR DESCRIPTION
##### Description of Change

Manually adjusts the sequence generators - for some reason the correct `last values` didn't get captured with the previous PR's DB export.

##### Related Issues

Related #833 

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

##### Project Area(s) Affected

- [x] Database schema

---

##### Checklist

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] pre-commit hooks have been run successfully

##### Testing

- [x] Manual testing performed
