### PR TITLE
docs: Add scripts README and move demo release scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,9 +319,9 @@ After key changes, redeploy affected services:
 | Script | Purpose |
 |--------|---------|
 | `aws-deploy.sh` | Deploy CloudFormation stacks (`-s demo`, `--only-stack`, `--update-ecs`, `--update-sam`) |
-| `release-demo.sh` | Update demo param files with latest ECR image tags from dev |
-| `release-demo-frontend.sh` | Build and deploy MDR frontend to S3/CloudFront from a git ref |
-| `verify-demo-images.sh` | Compare param file image tags against running ECS tasks |
+| `scripts/release-demo.sh` | Update demo param files with latest ECR image tags from dev |
+| `scripts/release-demo-frontend.sh` | Build and deploy MDR frontend to S3/CloudFront from a git ref |
+| `scripts/verify-demo-images.sh` | Compare param file image tags against running ECS tasks |
 | `scripts/setup-mdr-api-keys.sh` | Generate and store MDR service API keys in SSM Parameter Store |
 | `scripts/setup-graphql-api-keys.sh` | Generate and store GraphQL org1 API keys in SSM (service + workshop modes) |
 | `scripts/reset-mdr-database.sh` | Reset MDR database (flyway clean + migrate) when V1.1 SQL is replaced |
@@ -329,7 +329,7 @@ After key changes, redeploy affected services:
 
 ### Environment Differences
 - **Dev** uses `:latest` ECR image tags in param files; **demo** uses pinned version tags (e.g., `:1.2.3`)
-- `release-demo.sh` copies the current dev image tags to demo param files for promotion
+- `scripts/release-demo.sh` copies the current dev image tags to demo param files for promotion
 - Dev has a single-org setup (`dev-single-org`); demo has multi-org (`advisor-demo-org1/2/3`)
 
 ### Key Operational Notes
@@ -338,7 +338,7 @@ After key changes, redeploy affected services:
 - **Apple Silicon**: Docker images for Lambda must use `--platform linux/amd64` (already handled in scripts)
 - **SSM parameters**: ECS tasks fail to start if referenced SSM parameters are missing, even optional ones like `ApiKeys`
 - **Deploy sequentially**: Running multiple `aws-deploy.sh` commands in parallel causes SSO login conflicts
-- **MDR frontend**: Deployed to S3 + CloudFront (not ECS); use `release-demo-frontend.sh` for demo
+- **MDR frontend**: Deployed to S3 + CloudFront (not ECS); use `scripts/release-demo-frontend.sh` for demo
 - **Bash `grep -v` with `pipefail`**: In scripts using `set -o pipefail`, `grep -v` returns exit code 1 when all lines are filtered out (no matches). Wrap in `(grep -v ... || true)` to prevent script failure.
 
 ## Key Technologies

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -60,12 +60,12 @@ Run all commands from the **repository root** directory (not from `cloudformatio
 
 1. **Preview changes** (dry-run, no files modified):
    ```bash
-   AWS_PROFILE=lif ./release-demo.sh
+   AWS_PROFILE=lif ./scripts/release-demo.sh
    ```
 
 2. **Apply changes** to param files:
    ```bash
-   AWS_PROFILE=lif ./release-demo.sh --apply
+   AWS_PROFILE=lif ./scripts/release-demo.sh --apply
    ```
 
 3. **Deploy the updated stacks**:

--- a/docs/guides/demo_environment_update.md
+++ b/docs/guides/demo_environment_update.md
@@ -75,7 +75,7 @@ The `release-demo.sh` script reads every `cloudformation/demo-*.params` file tha
 ### 1a. Preview changes (dry-run)
 
 ```bash
-AWS_PROFILE=lif ./release-demo.sh
+AWS_PROFILE=lif ./scripts/release-demo.sh
 ```
 
 This shows which files would change and what the new tags would be. No files are modified.
@@ -83,7 +83,7 @@ This shows which files would change and what the new tags would be. No files are
 ### 1b. Apply changes
 
 ```bash
-AWS_PROFILE=lif ./release-demo.sh --apply
+AWS_PROFILE=lif ./scripts/release-demo.sh --apply
 ```
 
 Review the output to confirm all files updated successfully. Any failures are listed in the summary.
@@ -142,7 +142,7 @@ The MDR frontend is a static Vite/React app hosted on S3 + CloudFront — not an
 ### 3a. Preview (dry-run)
 
 ```bash
-AWS_PROFILE=lif ./release-demo-frontend.sh main
+AWS_PROFILE=lif ./scripts/release-demo-frontend.sh main
 ```
 
 This resolves the git ref, shows the commit SHA, target S3 bucket, and API URL, then exits without building or deploying.
@@ -150,14 +150,14 @@ This resolves the git ref, shows the commit SHA, target S3 bucket, and API URL, 
 ### 3b. Build and deploy
 
 ```bash
-AWS_PROFILE=lif ./release-demo-frontend.sh main --apply
+AWS_PROFILE=lif ./scripts/release-demo-frontend.sh main --apply
 ```
 
 You can use any git ref — a branch name, tag, or commit SHA:
 
 ```bash
-AWS_PROFILE=lif ./release-demo-frontend.sh v1.2.0 --apply
-AWS_PROFILE=lif ./release-demo-frontend.sh abc1234 --apply
+AWS_PROFILE=lif ./scripts/release-demo-frontend.sh v1.2.0 --apply
+AWS_PROFILE=lif ./scripts/release-demo-frontend.sh abc1234 --apply
 ```
 
 The script:
@@ -237,13 +237,13 @@ Create a PR so the pinned image tags are tracked in version control.
 |------|---------|
 | Audit MDR API keys | `AWS_PROFILE=lif ./scripts/setup-mdr-api-keys.sh demo` |
 | Create missing MDR API keys | `AWS_PROFILE=lif ./scripts/setup-mdr-api-keys.sh demo --apply` |
-| Preview image tag updates | `AWS_PROFILE=lif ./release-demo.sh` |
-| Apply image tag updates | `AWS_PROFILE=lif ./release-demo.sh --apply` |
+| Preview image tag updates | `AWS_PROFILE=lif ./scripts/release-demo.sh` |
+| Apply image tag updates | `AWS_PROFILE=lif ./scripts/release-demo.sh --apply` |
 | Deploy all stacks | `./aws-deploy.sh -s demo` |
 | Deploy one stack | `./aws-deploy.sh -s demo --only-stack <stack-name>` |
 | Force ECS redeployment | `./aws-deploy.sh -s demo --update-ecs` |
-| Preview MDR frontend deploy | `./release-demo-frontend.sh <git-ref>` |
-| Deploy MDR frontend | `./release-demo-frontend.sh <git-ref> --apply` |
+| Preview MDR frontend deploy | `./scripts/release-demo-frontend.sh <git-ref>` |
+| Deploy MDR frontend | `./scripts/release-demo-frontend.sh <git-ref> --apply` |
 | Deploy SAM databases | `./aws-deploy.sh -s demo --update-sam` |
 | Deploy MDR database only | `cd sam && bash deploy-sam.sh -s ../demo -d mdr-database` |
 | Deploy Dagster database only | `cd sam && bash deploy-sam.sh -s ../demo -d dagster-database` |
@@ -251,13 +251,13 @@ Create a PR so the pinned image tags are tracked in version control.
 
 ## Troubleshooting
 
-### `release-demo.sh` reports ECR access denied
+### `scripts/release-demo.sh` reports ECR access denied
 Ensure your AWS session is active and targeting the correct account:
 ```bash
 AWS_PROFILE=lif aws sts get-caller-identity
 ```
 
-### `release-demo.sh` reports "No image tagged 'latest'"
+### `scripts/release-demo.sh` reports "No image tagged 'latest'"
 The dev CI pipeline tags the most recent build as `latest`. If a repository has no `latest` tag, the dev build may not have completed successfully for that service.
 
 ### ECS task fails to start with "missing SSM parameter"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,14 @@ Utility scripts for managing deployments, credentials, and data. All AWS scripts
 |--------|---------|
 | `reset-mdr-database.sh` | **Destructive.** Wipes and recreates the MDR database via Flyway clean + migrate. Required when `V1.1__metadata_repository_init.sql` is replaced rather than versioned incrementally. |
 
+## Demo Release
+
+| Script | Purpose |
+|--------|---------|
+| `release-demo.sh` | Update demo CloudFormation parameter files with the latest image tags from dev ECR. Queries ECR for each `latest`-tagged image and resolves its version tag. |
+| `release-demo-frontend.sh` | Build the MDR frontend from a specific git ref and deploy to the demo S3 bucket + CloudFront. Usage: `./scripts/release-demo-frontend.sh <git-ref> --apply` |
+| `verify-demo-images.sh` | Compare image tags in demo param files against what is actually running in the demo ECS cluster. Reports matches, mismatches, and services not running. |
+
 ## ECS Operations
 
 | Script | Purpose |

--- a/scripts/release-demo-frontend.sh
+++ b/scripts/release-demo-frontend.sh
@@ -4,9 +4,9 @@
 # Builds the MDR frontend from a specific git ref and deploys to the demo S3 bucket.
 #
 # Usage:
-#   ./release-demo-frontend.sh <git-ref>              # Dry-run (preview)
-#   ./release-demo-frontend.sh <git-ref> --apply      # Build and deploy
-#   ./release-demo-frontend.sh --help                  # Show help
+#   ./scripts/release-demo-frontend.sh <git-ref>              # Dry-run (preview)
+#   ./scripts/release-demo-frontend.sh <git-ref> --apply      # Build and deploy
+#   ./scripts/release-demo-frontend.sh --help                  # Show help
 #
 
 set -euo pipefail

--- a/scripts/release-demo.sh
+++ b/scripts/release-demo.sh
@@ -8,9 +8,9 @@
 # Version: 1.0.0
 #
 # Usage:
-#   ./release-demo.sh              # Dry-run (preview changes)
-#   ./release-demo.sh --apply      # Apply changes to files
-#   ./release-demo.sh --help       # Show help
+#   ./scripts/release-demo.sh              # Dry-run (preview changes)
+#   ./scripts/release-demo.sh --apply      # Apply changes to files
+#   ./scripts/release-demo.sh --help       # Show help
 #
 
 set -euo pipefail

--- a/scripts/verify-demo-images.sh
+++ b/scripts/verify-demo-images.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # running in the demo ECS cluster.
 #
 # Usage:
-#   ./verify-demo-images.sh              # Compare all services
-#   ./verify-demo-images.sh --help       # Show help
+#   ./scripts/verify-demo-images.sh              # Compare all services
+#   ./scripts/verify-demo-images.sh --help       # Show help
 #
 
 # Colors


### PR DESCRIPTION
## Summary
- Add `scripts/README.md` documenting all utility scripts organized by category (AWS auth, CloudFormation, credentials, config sync, database, ECS ops, demo release, sample data)
- Move `release-demo.sh`, `release-demo-frontend.sh`, and `verify-demo-images.sh` from the repo root into `scripts/` for consistency
- Update all references in `CLAUDE.md`, `cloudformation/README.md`, `docs/guides/demo_environment_update.md`, and the scripts' own usage comments

## Test plan
- [ ] Verify all internal links and command examples reference the new `scripts/` paths
- [ ] Confirm `scripts/README.md` renders correctly on GitHub
- [ ] Spot-check that `git log --follow scripts/release-demo.sh` preserves history

🤖 Generated with [Claude Code](https://claude.com/claude-code)