### PR TITLE
LIF-771: Expose export transformation group endpoint

### DIFF
--- a/bases/lif/mdr_restapi/transformation_endpoint.py
+++ b/bases/lif/mdr_restapi/transformation_endpoint.py
@@ -1,6 +1,8 @@
+import json
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query, Request, Response, status
+from fastapi.encoders import jsonable_encoder
 from lif.mdr_dto.transformation_dto import (
     CreateTransformationDTO,
     CreateTransformationGroupDTO,
@@ -223,6 +225,20 @@ async def get_all_transformation_groups(
         }
 
     return {"total": total_count, "data": transformations}
+
+
+@router.get("/{transformation_group_id}/export")
+async def export_transformation_group(transformation_group_id: int, session: AsyncSession = Depends(get_session)):
+    _, group_data = await transformation_service.get_paginated_transformations_for_a_group(
+        session=session, group_id=transformation_group_id, pagination=False, make_exportable=True
+    )
+    # Normalize to JSON-safe Python objects
+    encoded = jsonable_encoder(group_data)
+    # Force download as .json
+    filename = f"transformation-group-{transformation_group_id}.json"
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+    payload = json.dumps(encoded, indent=2)
+    return Response(content=payload, media_type="application/json", headers=headers)
 
 
 @router.get("/{transformation_group_id}", response_model=Dict[str, Any])

--- a/components/lif/mdr_services/transformation_service.py
+++ b/components/lif/mdr_services/transformation_service.py
@@ -6,6 +6,7 @@ from lif.datatypes.mdr_sql_model import (
     DatamodelElementType,
     DataModelType,
     EntityAttributeAssociation,
+    ExpressionLanguageType,
     Transformation,
     TransformationAttribute,
     TransformationGroup,
@@ -1023,8 +1024,53 @@ async def get_transformation_group_by_id(session: AsyncSession, id: int):
     return transformation_group
 
 
+async def _resolve_entity_id_path_to_named_path(
+    session: AsyncSession, id_path: str, cache: dict[tuple[str, int], str]
+) -> str:
+    from lif.datatypes.mdr_sql_model import Attribute, Entity
+
+    ids = parse_transformation_path(id_path)
+    segments: list[str] = []
+
+    for i, raw_id in enumerate(ids):
+        is_last = i == len(ids) - 1
+        if not is_last and raw_id < 0:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unable to export - invalid path '{id_path}': non-terminal ID '{raw_id}' must be positive",
+            )
+        is_attribute = is_last and raw_id < 0
+        cleaned_id = abs(raw_id)
+        cache_key = ("attribute" if is_attribute else "entity", cleaned_id)
+
+        if cache_key not in cache:
+            record = await session.get(Attribute, cleaned_id) if is_attribute else await session.get(Entity, cleaned_id)
+            record_type = cache_key[0].capitalize()
+            if not record:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unable to export - {record_type} ID {cleaned_id} in path '{id_path}' not found",
+                )
+            if record.Deleted == True:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Unable to export - {record_type} ID {cleaned_id} in path '{id_path}' is deleted",
+                )
+            record_type_flag = "~" if is_attribute else ""
+            cache[cache_key] = f"{record.DataModelId}:{record_type_flag}{record.UniqueName}"
+
+        segments.append(cache[cache_key])
+
+    return ",".join(segments)
+
+
 async def get_paginated_transformations_for_a_group(
-    session: AsyncSession, group_id: int, offset: int = 0, limit: int = 10, pagination: bool = True
+    session: AsyncSession,
+    group_id: int,
+    offset: int = 0,
+    limit: int = 10,
+    pagination: bool = True,
+    make_exportable: bool = False,  # Only is honored when pagination is False and this is set to True.
 ):
     transformation_group = await get_transformation_group_by_id(session=session, id=group_id)
     transformation_group_dto = TransformationGroupDTO.from_orm(transformation_group)
@@ -1053,15 +1099,14 @@ async def get_paginated_transformations_for_a_group(
             .limit(limit)
         )
     else:
-        transformations_query = (
-            select(Transformation)
-            .where(Transformation.TransformationGroupId == group_id, Transformation.Deleted == False)
-            .order_by(Transformation.Id)
-        )
+        where_expressions = [Transformation.TransformationGroupId == group_id, Transformation.Deleted == False]
+        if make_exportable:
+            where_expressions.append(Transformation.ExpressionLanguage == ExpressionLanguageType.JSONata)
+        transformations_query = select(Transformation).where(*where_expressions).order_by(Transformation.Id)
 
     result = await session.execute(transformations_query)
     transformations = result.scalars().all()
-
+    entity_attribute_cache: dict[tuple[str, int], str] = {}
     for transformation in transformations:
         # Get related transformation attributes
         query = select(TransformationAttribute).where(
@@ -1100,6 +1145,11 @@ async def get_paginated_transformations_for_a_group(
                 ContributorOrganization=transformation_attribute.ContributorOrganization,
                 EntityIdPath=transformation_attribute.EntityIdPath,
             )
+
+            if make_exportable:
+                attribute_dto.EntityIdPath = await _resolve_entity_id_path_to_named_path(
+                    session=session, id_path=transformation_attribute.EntityIdPath, cache=entity_attribute_cache
+                )
 
             # Assign based on the attribute type (Source or Target)
             if transformation_attribute.AttributeType == "Source":

--- a/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
+++ b/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
@@ -1,11 +1,31 @@
 import inspect
+import re
 
 import pytest
+from deepdiff import DeepDiff
 
 from test.utils.lif.datasets.transform_deep_literal_attribute.loader import DatasetTransformDeepLiteralAttribute
 from test.utils.lif.datasets.transform_with_embeddings.loader import DatasetTransformWithEmbeddings
-from test.utils.lif.mdr.api import convert_unique_names_to_id_path, create_transformation, update_transformation
+from test.utils.lif.mdr.api import (
+    convert_unique_names_to_id_path,
+    create_transformation,
+    export_transformation_group,
+    update_transformation,
+)
 from test.utils.lif.translator.api import create_translation
+
+
+def _clean_jsonata_expression(expression: str) -> str:
+    """
+    Helper function to clean JSONata expressions for comparison, by removing extra whitespace.
+
+    Args:
+        expression (str): The JSONata expression to clean.
+
+    Returns:
+        str: The cleaned JSONata expression with extra whitespace removed.
+    """
+    return re.sub(r"\s+", " ", expression).strip()
 
 
 @pytest.mark.asyncio
@@ -202,17 +222,41 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
     """
 
     test_case_name = inspect.currentframe().f_code.co_name
+    group_contributor = f"{test_case_name}_contributor"
+    group_contributor_organization = f"{test_case_name}_contributor_org"
+    group_description = "group description"
+    group_notes = "group notes"
+    # Not precisely like the UX, that only sends the YYYY-MM-DD,
+    # but using the full format to avoid timezone issues with testing
+    group_creation_date = "2026-03-01T00:00:00Z"
+    group_activation_date = "2026-03-02T00:00:00Z"
+    group_deprecation_date = "2026-03-03T00:00:00Z"
 
     dataset_transform_with_embeddings = await DatasetTransformWithEmbeddings.prepare(
         async_client_mdr=async_client_mdr,
-        source_data_model_name=f"{test_case_name}_source",
-        target_data_model_name=f"{test_case_name}_target",
-        transformation_group_name=f"{test_case_name}_transform_group",
+        source_data_model_name=test_case_name,
+        target_data_model_name=test_case_name,
+        transformation_group_name=test_case_name,
+        transformation_group_contributor=group_contributor,
+        transformation_group_contributor_organization=group_contributor_organization,
+        transformation_group_description=group_description,
+        transformation_group_notes=group_notes,
+        transformation_group_creation_date=group_creation_date,
+        transformation_group_activation_date=group_activation_date,
+        transformation_group_deprecation_date=group_deprecation_date,
     )
 
     # Create transformations
-
-    _ = await create_transformation(
+    transformation1__contributor = f"{test_case_name}_transformation1_contributor"
+    transformation1__contributor_organization = f"{test_case_name}_contributor_org"
+    transformation1__description = "transformation1 description"
+    transformation1__notes = "transformation1 notes"
+    # Not precisely like the UX, that only sends the YYYY-MM-DD,
+    # but using the full format to avoid timezone issues with testing
+    transformation1__creation_date = "2021-03-01T00:00:00Z"
+    transformation1__activation_date = "2021-03-02T00:00:00Z"
+    transformation1__deprecation_date = "2021-03-03T00:00:00Z"
+    transformation1_data = await create_transformation(
         async_client_mdr=async_client_mdr,
         transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
         source_parent_entity_id=None,
@@ -225,7 +269,7 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
         transformation_name="User.Workplace.Abilities.Skills.LevelOfSkillAbility",
     )
 
-    _ = await create_transformation(
+    transformation2_data = await create_transformation(
         async_client_mdr=async_client_mdr,
         transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
         source_parent_entity_id=None,
@@ -238,7 +282,7 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
         transformation_name="User.Abilities.Skills.LevelOfSkillAbility",
     )
 
-    _ = await create_transformation(
+    transformation3_data = await create_transformation(
         async_client_mdr=async_client_mdr,
         transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
         source_parent_entity_id=None,
@@ -275,6 +319,183 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
             "Preferences": {"WorkPreference": "Advanced"},
         }
     }
+
+    # Check the export
+
+    export_data = await export_transformation_group(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        headers=mdr_api_headers,
+        expected_status_code=200,
+    )
+    source_data_model_id = dataset_transform_with_embeddings.source_data_model_id
+    target_data_model_id = dataset_transform_with_embeddings.target_data_model_id
+    expected_data = {
+        "Id": dataset_transform_with_embeddings.transformation_group_id,
+        "SourceDataModelId": source_data_model_id,
+        "TargetDataModelId": target_data_model_id,
+        "SourceDataModelName": f"{test_case_name}_source",
+        "TargetDataModelName": f"{test_case_name}_target",
+        "Name": f"{test_case_name}_transform_group",
+        "GroupVersion": "1.0",
+        "Description": group_description,
+        "Notes": group_notes,
+        "CreationDate": group_creation_date,
+        "ActivationDate": group_activation_date,
+        "DeprecationDate": group_deprecation_date,
+        "Contributor": group_contributor,
+        "ContributorOrganization": group_contributor_organization,
+        "Transformations": [
+            {
+                "Id": transformation1_data["Id"],
+                "TransformationGroupId": dataset_transform_with_embeddings.transformation_group_id,
+                "Name": "User.Workplace.Abilities.Skills.LevelOfSkillAbility",
+                "Expression": "",  # Check later on
+                "ExpressionLanguage": "JSONata",
+                "Notes": None,
+                "Alignment": None,
+                "CreationDate": None,
+                "ActivationDate": None,
+                "DeprecationDate": None,
+                "Contributor": None,
+                "ContributorOrganization": None,
+                "SourceAttributes": [
+                    {
+                        "AttributeId": dataset_transform_with_embeddings.flow1_source_attribute_id,
+                        "EntityId": dataset_transform_with_embeddings.flow1_source_parent_entity_id,
+                        "AttributeName": "SkillLevel",
+                        "AttributeType": "Source",
+                        "Notes": None,
+                        "CreationDate": None,
+                        "ActivationDate": None,
+                        "DeprecationDate": None,
+                        "Contributor": None,
+                        "ContributorOrganization": None,
+                        "EntityIdPath": f"{source_data_model_id}:person,{source_data_model_id}:person.courses,{source_data_model_id}:person.courses.skillsgainedfromcourses,{source_data_model_id}:~person.courses.skillsgainedfromcourses.skilllevel",
+                    }
+                ],
+                "TargetAttribute": {
+                    "AttributeId": dataset_transform_with_embeddings.flow1_target_attribute_id,
+                    "EntityId": dataset_transform_with_embeddings.flow1_target_parent_entity_id,
+                    "AttributeName": "LevelOfSkillAbility",
+                    "AttributeType": "Target",
+                    "Notes": None,
+                    "CreationDate": None,
+                    "ActivationDate": None,
+                    "DeprecationDate": None,
+                    "Contributor": None,
+                    "ContributorOrganization": None,
+                    "EntityIdPath": f"{target_data_model_id}:user,{target_data_model_id}:user.abilities,{target_data_model_id}:user.abilities.skills,{target_data_model_id}:~user.abilities.skills.levelofskillability",
+                },
+            },
+            {
+                "Id": transformation2_data["Id"],
+                "TransformationGroupId": dataset_transform_with_embeddings.transformation_group_id,
+                "Name": "User.Abilities.Skills.LevelOfSkillAbility",
+                "Expression": "",  # Check later on
+                "ExpressionLanguage": "JSONata",
+                "Notes": None,
+                "Alignment": None,
+                "CreationDate": None,
+                "ActivationDate": None,
+                "DeprecationDate": None,
+                "Contributor": None,
+                "ContributorOrganization": None,
+                "SourceAttributes": [
+                    {
+                        "AttributeId": dataset_transform_with_embeddings.flow2_source_attribute_id,
+                        "EntityId": dataset_transform_with_embeddings.flow2_source_parent_entity_id,
+                        "AttributeName": "DurationAtProfession",
+                        "AttributeType": "Source",
+                        "Notes": None,
+                        "CreationDate": None,
+                        "ActivationDate": None,
+                        "DeprecationDate": None,
+                        "Contributor": None,
+                        "ContributorOrganization": None,
+                        "EntityIdPath": f"{source_data_model_id}:person,{source_data_model_id}:person.employment,{source_data_model_id}:person.employment.profession,{source_data_model_id}:~person.employment.profession.durationatprofession",
+                    }
+                ],
+                "TargetAttribute": {
+                    "AttributeId": dataset_transform_with_embeddings.flow2_target_attribute_id,
+                    "EntityId": dataset_transform_with_embeddings.flow2_target_parent_entity_id,
+                    "AttributeName": "LevelOfSkillAbility",
+                    "AttributeType": "Target",
+                    "Notes": None,
+                    "CreationDate": None,
+                    "ActivationDate": None,
+                    "DeprecationDate": None,
+                    "Contributor": None,
+                    "ContributorOrganization": None,
+                    "EntityIdPath": f"{target_data_model_id}:user,{target_data_model_id}:user.abilities,{target_data_model_id}:user.abilities.skills,{target_data_model_id}:~user.abilities.skills.levelofskillability",
+                },
+            },
+            {
+                "Id": transformation3_data["Id"],
+                "TransformationGroupId": dataset_transform_with_embeddings.transformation_group_id,
+                "Name": "User.Preferences.WorkPreference",
+                "Expression": "",  # Check later on
+                "ExpressionLanguage": "JSONata",
+                "Notes": None,
+                "Alignment": None,
+                "CreationDate": None,
+                "ActivationDate": None,
+                "DeprecationDate": None,
+                "Contributor": None,
+                "ContributorOrganization": None,
+                "SourceAttributes": [
+                    {
+                        "AttributeId": dataset_transform_with_embeddings.flow3_source_attribute_id,
+                        "EntityId": dataset_transform_with_embeddings.flow3_source_parent_entity_id,
+                        "AttributeName": "SkillLevel",
+                        "AttributeType": "Source",
+                        "Notes": None,
+                        "CreationDate": None,
+                        "ActivationDate": None,
+                        "DeprecationDate": None,
+                        "Contributor": None,
+                        "ContributorOrganization": None,
+                        "EntityIdPath": f"{source_data_model_id}:person,{source_data_model_id}:person.courses,{source_data_model_id}:person.courses.skillsgainedfromcourses,{source_data_model_id}:~person.courses.skillsgainedfromcourses.skilllevel",
+                    }
+                ],
+                "TargetAttribute": {
+                    "AttributeId": dataset_transform_with_embeddings.flow3_target_attribute_id,
+                    "EntityId": dataset_transform_with_embeddings.flow3_target_parent_entity_id,
+                    "AttributeName": "WorkPreference",
+                    "AttributeType": "Target",
+                    "Notes": None,
+                    "CreationDate": None,
+                    "ActivationDate": None,
+                    "DeprecationDate": None,
+                    "Contributor": None,
+                    "ContributorOrganization": None,
+                    "EntityIdPath": f"{target_data_model_id}:user,{target_data_model_id}:user.preferences,{target_data_model_id}:~user.preferences.workpreference",
+                },
+            },
+        ],
+        "Tags": None,
+    }
+    diff = DeepDiff(
+        export_data, expected_data, exclude_regex_paths=[r"root\['Transformations'\]\[\d+\]\['Expression'\]"]
+    )
+    assert diff == {}, diff
+
+    # Check expressions
+    cleaned_expression0_actual = _clean_jsonata_expression(export_data["Transformations"][0]["Expression"])
+    cleaned_expression0_expected = _clean_jsonata_expression(
+        '{ "User": { "Workplace": { "Abilities": { "Skills": { "LevelOfSkillAbility": Person.Employment.SkillsGainedFromCourses.SkillLevel } } } } }'
+    )
+    assert cleaned_expression0_actual == cleaned_expression0_expected
+    cleaned_expression1_actual = _clean_jsonata_expression(export_data["Transformations"][1]["Expression"])
+    cleaned_expression1_expected = _clean_jsonata_expression(
+        '{ "User": { "Abilities": { "Skills": { "LevelOfSkillAbility": Person.Employment.Profession.DurationAtProfession } } } }'
+    )
+    assert cleaned_expression1_actual == cleaned_expression1_expected
+    cleaned_expression2_actual = _clean_jsonata_expression(export_data["Transformations"][2]["Expression"])
+    cleaned_expression2_expected = _clean_jsonata_expression(
+        '{ "User": { "Preferences": { "WorkPreference": Person.Courses.SkillsGainedFromCourses.SkillLevel } } }'
+    )
+    assert cleaned_expression2_actual == cleaned_expression2_expected
 
 
 @pytest.mark.asyncio

--- a/test/utils/lif/datasets/transform_with_embeddings/loader.py
+++ b/test/utils/lif/datasets/transform_with_embeddings/loader.py
@@ -44,6 +44,13 @@ class DatasetTransformWithEmbeddings:
         source_data_model_name: str,
         target_data_model_name: str,
         transformation_group_name: str,
+        transformation_group_contributor: str | None = None,
+        transformation_group_contributor_organization: str | None = None,
+        transformation_group_description: str | None = None,
+        transformation_group_notes: str | None = None,
+        transformation_group_creation_date: str | None = None,
+        transformation_group_activation_date: str | None = None,
+        transformation_group_deprecation_date: str | None = None,
     ) -> "DatasetTransformWithEmbeddings":
         """Prepare the dataset by creating source/target data models and transformation group."""
 
@@ -133,7 +140,7 @@ class DatasetTransformWithEmbeddings:
         (target_data_model_id, target_schema) = await create_data_model_by_upload(
             async_client_mdr=async_client_mdr,
             schema_path=Path(__file__).parent / "transform_with_embeddings_target.json",
-            data_model_name=f"{source_data_model_name}_target",
+            data_model_name=f"{target_data_model_name}_target",
             data_model_type="SourceSchema",
         )
         flow1_target_parent_entity_id = find_object_property_by_unique_name(
@@ -193,6 +200,13 @@ class DatasetTransformWithEmbeddings:
             source_data_model_id=source_data_model_id,
             target_data_model_id=target_data_model_id,
             group_name=f"{transformation_group_name}_transform_group",
+            group_contributor=transformation_group_contributor,
+            group_contributor_organization=transformation_group_contributor_organization,
+            group_description=transformation_group_description,
+            group_notes=transformation_group_notes,
+            group_creation_date=transformation_group_creation_date,
+            group_activation_date=transformation_group_activation_date,
+            group_deprecation_date=transformation_group_deprecation_date,
         )
 
         return cls(

--- a/test/utils/lif/mdr/api.py
+++ b/test/utils/lif/mdr/api.py
@@ -110,6 +110,13 @@ async def create_transformation_groups(
     source_data_model_id: str,
     target_data_model_id: str,
     group_name: str,
+    group_contributor: str | None = None,
+    group_contributor_organization: str | None = None,
+    group_description: str | None = None,
+    group_notes: str | None = None,
+    group_creation_date: str | None = None,
+    group_activation_date: str | None = None,
+    group_deprecation_date: str | None = None,
     headers: dict = HEADER_MDR_API_KEY_GRAPHQL,
 ) -> str:
     """
@@ -120,6 +127,13 @@ async def create_transformation_groups(
         source_data_model_id: The ID of the source data model
         target_data_model_id: The ID of the target data model
         group_name: The name to assign to the transformation group
+        group_contributor: The name of the contributor for the transformation group (optional)
+        group_contributor_organization: The organization of the contributor for the transformation group (optional)
+        group_description: The description of the transformation group (optional)
+        group_notes: Notes for the transformation group (optional)
+        group_creation_date: The creation date of the transformation group (optional)
+        group_activation_date: The activation date of the transformation group (optional)
+        group_deprecation_date: The deprecation date of the transformation group (optional)
         headers: Optional headers to include in the request (default is HEADER_MDR_API_KEY_GRAPHQL)
 
     Returns:
@@ -127,39 +141,55 @@ async def create_transformation_groups(
     """
 
     # Create transformation group between source and target
+    payload = {
+        "SourceDataModelId": source_data_model_id,
+        "TargetDataModelId": target_data_model_id,
+        "Name": group_name,
+        "GroupVersion": "1.0",
+    }
+    if group_contributor:
+        payload["Contributor"] = group_contributor
+    if group_contributor_organization:
+        payload["ContributorOrganization"] = group_contributor_organization
+    if group_description:
+        payload["Description"] = group_description
+    if group_notes:
+        payload["Notes"] = group_notes
+    if group_creation_date:
+        payload["CreationDate"] = group_creation_date
+    if group_activation_date:
+        payload["ActivationDate"] = group_activation_date
+    if group_deprecation_date:
+        payload["DeprecationDate"] = group_deprecation_date
 
-    response = await async_client_mdr.post(
-        "/transformation_groups/",
-        headers=headers,
-        json={
-            "SourceDataModelId": source_data_model_id,
-            "TargetDataModelId": target_data_model_id,
-            "Name": group_name,
-            "GroupVersion": "1.0",
-        },
-    )
+    response = await async_client_mdr.post("/transformation_groups/", headers=headers, json=payload)
 
     # Confirm transformation group response and gather ID
 
     assert response.status_code == 201, str(response.text) + str(response.headers)
-    group_id = response.json()["Id"]
-    assert response.json() == {
-        "Id": group_id,
-        "SourceDataModelId": source_data_model_id,
-        "TargetDataModelId": target_data_model_id,
-        "SourceDataModelName": None,
-        "TargetDataModelName": None,
-        "Name": group_name,
-        "GroupVersion": "1.0",
-        "Description": None,
-        "Notes": None,
-        "CreationDate": None,
-        "ActivationDate": None,
-        "DeprecationDate": None,
-        "Contributor": None,
-        "ContributorOrganization": None,
-        "Tags": None,
-    }
+    response_data = response.json()
+    group_id = response_data["Id"]
+    diff = DeepDiff(
+        response_data,
+        {
+            "Id": group_id,
+            "SourceDataModelId": source_data_model_id,
+            "TargetDataModelId": target_data_model_id,
+            "SourceDataModelName": None,
+            "TargetDataModelName": None,
+            "Name": group_name,
+            "GroupVersion": "1.0",
+            "Description": group_description,
+            "Notes": group_notes,
+            "CreationDate": group_creation_date,
+            "ActivationDate": group_activation_date,
+            "DeprecationDate": group_deprecation_date,
+            "Contributor": group_contributor,
+            "ContributorOrganization": group_contributor_organization,
+            "Tags": None,
+        },
+    )
+    assert diff == {}, f"Failed to create transformation group: {diff}"
 
     return group_id
 
@@ -179,7 +209,7 @@ async def create_transformation(
     headers: dict = HEADER_MDR_API_KEY_GRAPHQL,
     expected_status_code: int = 201,
     expected_response: Optional[dict] = None,
-) -> str:
+) -> dict:
     """
     Helper function to create a transform between a single source attribute and a target attribute
 
@@ -197,7 +227,7 @@ async def create_transformation(
         headers: Optional headers to include in the request (default is HEADER_MDR_API_KEY_GRAPHQL)
 
     Returns:
-        The ID of the created transformation
+        The created transformation as a dictionary
     """
     response = await async_client_mdr.post(
         "/transformation_groups/transformations/",
@@ -321,3 +351,34 @@ async def update_transformation(
             assert response.json() == expected_response, str(response.text) + str(response.headers)
         return response.text
     return None
+
+
+async def export_transformation_group(
+    *,
+    async_client_mdr: AsyncClient,
+    transformation_group_id: str,
+    headers: dict = HEADER_MDR_API_KEY_GRAPHQL,
+    expected_status_code: int = 200,
+    expected_response_data: Optional[dict] = None,
+) -> dict:
+    """
+    Helper function to export transformation group
+
+    Args:
+        async_client_mdr: An instance of AsyncClient to make HTTP requests to the MDR API
+        transformation_group_id: The ID of the transformation group to export
+        headers: Optional headers to include in the request (default is HEADER_MDR_API_KEY_GRAPHQL)
+
+    Returns:
+        The response json
+    """
+    response = await async_client_mdr.get(f"/transformation_groups/{transformation_group_id}/export", headers=headers)
+
+    # Confirm response
+    response_json = response.json()
+    assert response.status_code == expected_status_code, str(response.text) + str(response.headers)
+    if expected_response_data is not None:
+        diff = DeepDiff(response_json, expected_response_data)
+        assert diff == {}, diff
+
+    return response_json


### PR DESCRIPTION
##### Description of Change

Introduces a new export transformation group endpoint, enabling users to download a given transformation group and it's transformations in a JSON format suitable for external use.

There will be a follow up PR(s) to harden the endpoint and possibly expand the testing, but this will allow the basic functionality so the FE can be wired in.

##### Related Issues

Related to #771 

##### Type of Change

- [x] New feature (non-breaking change which adds functionality)

##### Project Area(s) Affected

- [x] bases/
- [x] components/
- [x] API endpoints
- [ ] Documentation
- [x] Testing

---

##### Checklist

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] tests are included (unit and/or integration tests)
- [ ] documentation is changed or added (in /docs directory)
- [x] code passes linting checks (`uv run ruff check`)
- [x] code passes formatting checks (`uv run ruff format`)
- [ ] code passes type checking (`uv run ty check`)
- [x] pre-commit hooks have been run successfully
- [ ] database schema changes: migration files created and CHANGELOG.md updated
- [ ] API changes: base (Python code) documentation in `docs/`
      and project README updated
- [ ] configuration changes: relevant folder README updated
- [ ] breaking changes: added to MIGRATION.md with upgrade instructions
      and CHANGELOG.md entry

##### Testing
<!-- Describe the testing you've done -->

- [x] Manual testing performed
- [x] Automated tests added/updated
- [ ] Integration testing completed

##### Additional Notes
<!-- Any additional information that reviewers should know -->
