### PR TITLE
Issue #880: Add SPA fallback nginx config to Advisor frontend

### DIFF
--- a/frontends/lif_advisor_app/Dockerfile
+++ b/frontends/lif_advisor_app/Dockerfile
@@ -25,8 +25,8 @@ FROM nginx:1.26-alpine AS serve
 # Copy built files from the previous stage
 COPY --from=build /app/dist /usr/share/nginx/html/
 
-# Optionally: copy custom nginx config - for SPA, you'll need this, similar to mdr-frontend
-# COPY ./docker/nginx.conf /etc/nginx/conf.d/default.conf
+# Copy custom nginx config for SPA fallback routing
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose default Nginx port
 EXPOSE 80

--- a/frontends/lif_advisor_app/nginx.conf
+++ b/frontends/lif_advisor_app/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
##### Description of Change

Adds an `nginx.conf` with `try_files` SPA fallback routing to the Advisor frontend, matching the existing MDR frontend pattern.

**What problem does this solve?**
When a user enters a wrong password, the app navigates to `/login`. Without SPA fallback routing, nginx returns a 404 page instead of serving the React app. The user sees a blank "404 Not Found" page and must manually navigate back.

**What is the solution?**
- Add `nginx.conf` with `try_files $uri /index.html;` (same as `frontends/mdr-frontend/nginx.conf`)
- Uncomment and update the `COPY` line in the Dockerfile to install the config

**How should reviewers test this?**
- Build and run the Advisor Docker image
- Enter wrong credentials on the login page
- Verify the error message appears and the login form stays visible (instead of a 404)

##### Related Issues

Closes #880

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

##### Project Area(s) Affected

- [x] frontends/

---

##### Checklist

- [x] commit message follows commit guidelines (see commitlint.config.mjs)

##### Testing

- [ ] Manual testing performed
- [ ] Automated tests added/updated
- [ ] Integration testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)