### PR TITLE
Issue 771: Harden export API to fail due to no valid transforms

### DIFF
--- a/bases/lif/mdr_restapi/transformation_endpoint.py
+++ b/bases/lif/mdr_restapi/transformation_endpoint.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, Query, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from lif.mdr_dto.transformation_dto import (
     CreateTransformationDTO,
@@ -229,9 +229,18 @@ async def get_all_transformation_groups(
 
 @router.get("/{transformation_group_id}/export")
 async def export_transformation_group(transformation_group_id: int, session: AsyncSession = Depends(get_session)):
-    _, group_data = await transformation_service.get_paginated_transformations_for_a_group(
+    total_count, group_data = await transformation_service.get_paginated_transformations_for_a_group(
         session=session, group_id=transformation_group_id, pagination=False, make_exportable=True
     )
+    if total_count == 0:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "There are no valid transformations to export for this group / version. "
+                "Please add a transformation to this group's version and retry the export."
+            ),
+        )
+
     # Normalize to JSON-safe Python objects
     encoded = jsonable_encoder(group_data)
     # Force download as .json

--- a/components/lif/mdr_services/transformation_service.py
+++ b/components/lif/mdr_services/transformation_service.py
@@ -1087,6 +1087,9 @@ async def get_paginated_transformations_for_a_group(
         .where(Transformation.TransformationGroupId == group_id)
         .where(Transformation.Deleted == False)
     )
+    if not pagination and make_exportable:
+        total_query = total_query.where(Transformation.ExpressionLanguage == ExpressionLanguageType.JSONata)
+
     total_result = await session.execute(total_query)
     total_count = total_result.scalar()
 

--- a/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
+++ b/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
@@ -9,6 +9,7 @@ from test.utils.lif.datasets.transform_with_embeddings.loader import DatasetTran
 from test.utils.lif.mdr.api import (
     convert_unique_names_to_id_path,
     create_transformation,
+    delete_transformation,
     export_transformation_group,
     update_transformation,
 )
@@ -295,6 +296,38 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
         transformation_name="User.Preferences.WorkPreference",
     )
 
+    transformation_data_to_be_deleted = await create_transformation(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        source_parent_entity_id=None,
+        source_attribute_id=dataset_transform_with_embeddings.flow3_source_attribute_id,
+        source_entity_path=dataset_transform_with_embeddings.flow3_source_entity_id_path,
+        target_parent_entity_id=None,
+        target_attribute_id=dataset_transform_with_embeddings.flow3_target_attribute_id,
+        target_entity_path=dataset_transform_with_embeddings.flow3_target_entity_id_path,
+        mapping_expression="{ }",
+        transformation_name="Transformation To Be Deleted",
+    )
+
+    await delete_transformation(
+        async_client_mdr=async_client_mdr, transformation_id=transformation_data_to_be_deleted["Id"]
+    )
+
+    # Add a non-JSONata transformation to confirm it is ignored in the export
+    await create_transformation(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        source_parent_entity_id=None,
+        source_attribute_id=dataset_transform_with_embeddings.flow2_source_attribute_id,
+        source_entity_path=dataset_transform_with_embeddings.flow2_source_entity_id_path,
+        target_parent_entity_id=None,
+        target_attribute_id=dataset_transform_with_embeddings.flow2_target_attribute_id,
+        target_entity_path=dataset_transform_with_embeddings.flow2_target_entity_id_path,
+        expression_language="LIF_Pseudo_Code",
+        mapping_expression="foo(bar())",
+        transformation_name="Non-JSONata expression!",
+    )
+
     # Use the transformations via the Translator endpoint
 
     translated_json = await create_translation(
@@ -496,6 +529,173 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
         '{ "User": { "Preferences": { "WorkPreference": Person.Courses.SkillsGainedFromCourses.SkillLevel } } }'
     )
     assert cleaned_expression2_actual == cleaned_expression2_expected
+
+
+@pytest.mark.asyncio
+async def test_transforms_export_fail_with_no_transforms(async_client_mdr, mdr_api_headers):
+    """
+    Confirms the export will fail nicely if there are no transformations in the group.
+
+    """
+
+    test_case_name = inspect.currentframe().f_code.co_name
+    group_contributor = f"{test_case_name}_contributor"
+    group_contributor_organization = f"{test_case_name}_contributor_org"
+    group_description = "group description"
+    group_notes = "group notes"
+    # Not precisely like the UX, that only sends the YYYY-MM-DD,
+    # but using the full format to avoid timezone issues with testing
+    group_creation_date = "2026-03-01T00:00:00Z"
+    group_activation_date = "2026-03-02T00:00:00Z"
+    group_deprecation_date = "2026-03-03T00:00:00Z"
+
+    dataset_transform_with_embeddings = await DatasetTransformWithEmbeddings.prepare(
+        async_client_mdr=async_client_mdr,
+        source_data_model_name=test_case_name,
+        target_data_model_name=test_case_name,
+        transformation_group_name=test_case_name,
+        transformation_group_contributor=group_contributor,
+        transformation_group_contributor_organization=group_contributor_organization,
+        transformation_group_description=group_description,
+        transformation_group_notes=group_notes,
+        transformation_group_creation_date=group_creation_date,
+        transformation_group_activation_date=group_activation_date,
+        transformation_group_deprecation_date=group_deprecation_date,
+    )
+
+    await export_transformation_group(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        headers=mdr_api_headers,
+        expected_status_code=400,
+        expected_response_data={
+            "detail": (
+                "There are no valid transformations to export for this group / version. "
+                "Please add a transformation to this group's version and retry the export."
+            )
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_transforms_export_fail_with_only_non_jsonata_transform(async_client_mdr, mdr_api_headers):
+    """
+    Confirms the export will fail nicely if there are no JSONata transformations in the group.
+
+    """
+
+    test_case_name = inspect.currentframe().f_code.co_name
+    group_contributor = f"{test_case_name}_contributor"
+    group_contributor_organization = f"{test_case_name}_contributor_org"
+    group_description = "group description"
+    group_notes = "group notes"
+    # Not precisely like the UX, that only sends the YYYY-MM-DD,
+    # but using the full format to avoid timezone issues with testing
+    group_creation_date = "2026-03-01T00:00:00Z"
+    group_activation_date = "2026-03-02T00:00:00Z"
+    group_deprecation_date = "2026-03-03T00:00:00Z"
+
+    dataset_transform_with_embeddings = await DatasetTransformWithEmbeddings.prepare(
+        async_client_mdr=async_client_mdr,
+        source_data_model_name=test_case_name,
+        target_data_model_name=test_case_name,
+        transformation_group_name=test_case_name,
+        transformation_group_contributor=group_contributor,
+        transformation_group_contributor_organization=group_contributor_organization,
+        transformation_group_description=group_description,
+        transformation_group_notes=group_notes,
+        transformation_group_creation_date=group_creation_date,
+        transformation_group_activation_date=group_activation_date,
+        transformation_group_deprecation_date=group_deprecation_date,
+    )
+
+    await create_transformation(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        source_parent_entity_id=None,
+        source_attribute_id=dataset_transform_with_embeddings.flow2_source_attribute_id,
+        source_entity_path=dataset_transform_with_embeddings.flow2_source_entity_id_path,
+        target_parent_entity_id=None,
+        target_attribute_id=dataset_transform_with_embeddings.flow2_target_attribute_id,
+        target_entity_path=dataset_transform_with_embeddings.flow2_target_entity_id_path,
+        expression_language="LIF_Pseudo_Code",
+        mapping_expression="foo(bar())",
+        transformation_name="Non-JSONata expression!",
+    )
+
+    await export_transformation_group(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        headers=mdr_api_headers,
+        expected_status_code=400,
+        expected_response_data={
+            "detail": (
+                "There are no valid transformations to export for this group / version. "
+                "Please add a transformation to this group's version and retry the export."
+            )
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_transforms_export_fail_with_only_deleted_jsonata_transform(async_client_mdr, mdr_api_headers):
+    """
+    Confirms the export will fail nicely if there are no active JSONata transformations in the group.
+
+    """
+
+    test_case_name = inspect.currentframe().f_code.co_name
+    group_contributor = f"{test_case_name}_contributor"
+    group_contributor_organization = f"{test_case_name}_contributor_org"
+    group_description = "group description"
+    group_notes = "group notes"
+    # Not precisely like the UX, that only sends the YYYY-MM-DD,
+    # but using the full format to avoid timezone issues with testing
+    group_creation_date = "2026-03-01T00:00:00Z"
+    group_activation_date = "2026-03-02T00:00:00Z"
+    group_deprecation_date = "2026-03-03T00:00:00Z"
+
+    dataset_transform_with_embeddings = await DatasetTransformWithEmbeddings.prepare(
+        async_client_mdr=async_client_mdr,
+        source_data_model_name=test_case_name,
+        target_data_model_name=test_case_name,
+        transformation_group_name=test_case_name,
+        transformation_group_contributor=group_contributor,
+        transformation_group_contributor_organization=group_contributor_organization,
+        transformation_group_description=group_description,
+        transformation_group_notes=group_notes,
+        transformation_group_creation_date=group_creation_date,
+        transformation_group_activation_date=group_activation_date,
+        transformation_group_deprecation_date=group_deprecation_date,
+    )
+
+    transform_data = await create_transformation(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        source_parent_entity_id=None,
+        source_attribute_id=dataset_transform_with_embeddings.flow2_source_attribute_id,
+        source_entity_path=dataset_transform_with_embeddings.flow2_source_entity_id_path,
+        target_parent_entity_id=None,
+        target_attribute_id=dataset_transform_with_embeddings.flow2_target_attribute_id,
+        target_entity_path=dataset_transform_with_embeddings.flow2_target_entity_id_path,
+        mapping_expression="{}",
+        transformation_name="Will be deleted!",
+    )
+
+    await delete_transformation(async_client_mdr=async_client_mdr, transformation_id=transform_data["Id"])
+
+    await export_transformation_group(
+        async_client_mdr=async_client_mdr,
+        transformation_group_id=dataset_transform_with_embeddings.transformation_group_id,
+        headers=mdr_api_headers,
+        expected_status_code=400,
+        expected_response_data={
+            "detail": (
+                "There are no valid transformations to export for this group / version. "
+                "Please add a transformation to this group's version and retry the export."
+            )
+        },
+    )
 
 
 @pytest.mark.asyncio

--- a/test/utils/lif/mdr/api.py
+++ b/test/utils/lif/mdr/api.py
@@ -206,6 +206,7 @@ async def create_transformation(
     target_entity_path: str,  # "User.Skills"
     mapping_expression: str,  # '{ "User": { "Skills": { "Genre": Person.Courses.Grade } } }'
     transformation_name: str,  # "User.Skills.Genre",
+    expression_language: str = "JSONata",
     headers: dict = HEADER_MDR_API_KEY_GRAPHQL,
     expected_status_code: int = 201,
     expected_response: Optional[dict] = None,
@@ -225,6 +226,7 @@ async def create_transformation(
         mapping_expression: The JSONata expression that defines the transformation logic (e.g., '{ "User": { "Skills": { "Genre": Person.Courses.Grade } } }')
         transformation_name: The name to assign to the transformation
         headers: Optional headers to include in the request (default is HEADER_MDR_API_KEY_GRAPHQL)
+        expression_language: The language of the expression (default is "JSONata")
 
     Returns:
         The created transformation as a dictionary
@@ -233,7 +235,7 @@ async def create_transformation(
         "/transformation_groups/transformations/",
         headers=headers,
         json={
-            "ExpressionLanguage": "JSONata",
+            "ExpressionLanguage": expression_language,
             "TransformationGroupId": transformation_group_id,
             "Expression": mapping_expression,
             "Name": transformation_name,
@@ -266,7 +268,7 @@ async def create_transformation(
                 "TransformationGroupId": transformation_group_id,
                 "Name": transformation_name,
                 "Expression": mapping_expression,
-                "ExpressionLanguage": "JSONata",
+                "ExpressionLanguage": expression_language,
                 "Notes": None,
                 "Alignment": None,
                 "CreationDate": None,
@@ -311,6 +313,39 @@ async def create_transformation(
         if expected_response is not None:
             assert response.json() == expected_response, str(response.text) + str(response.headers)
         return response.json()
+
+
+async def delete_transformation(
+    *,
+    async_client_mdr: AsyncClient,
+    transformation_id: str,
+    headers: dict = HEADER_MDR_API_KEY_GRAPHQL,
+    expected_status_code: int = 200,
+    expected_response: Optional[dict] = None,
+) -> dict:
+    """
+    Helper function to delete a transform
+
+    Args:
+        async_client_mdr: An instance of AsyncClient to make HTTP requests to the MDR API
+        transformation_id: The ID of the transformation to delete
+        headers: Optional headers to include in the request (default is HEADER_MDR_API_KEY_GRAPHQL)
+        expected_status_code: The expected HTTP status code of the response (default is 200)
+        expected_response: The expected response body as a dictionary (optional)
+
+    Returns:
+        The response from the delete operation as a dictionary
+    """
+    response = await async_client_mdr.delete(
+        f"/transformation_groups/transformations/{transformation_id}", headers=headers
+    )
+
+    # Confirm transform response and gather ID
+    response_json = response.json()
+    assert response.status_code == expected_status_code, str(response.text) + str(response.headers)
+    if expected_response is not None:
+        assert response_json == expected_response, str(response.text) + str(response.headers)
+    return response_json
 
 
 async def update_transformation(


### PR DESCRIPTION
API now fails when the transform group / version to export contains no valid transformations (non-deleted, expression language is JSONata).


##### Related Issues

#771 


##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


##### Checklist

<!-- REMOVE ITEMS that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] tests are included (unit and/or integration tests)
- [x] pre-commit hooks have been run successfully


##### Testing

- [x] Manual testing performed
- [x] Automated tests added/updated
