### PR TITLE
Issue #882: Promote MDR API to demo and wire Cognito into demo frontend script

### DIFF
--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -57,7 +57,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-03-30-20-00-57-171376d"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-04-17-01-26-19-64a2b7f"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cspell.json
+++ b/cspell.json
@@ -152,6 +152,7 @@
         "VITE",
         "webassets",
         "workpreference",
+        "worktree",
         "xform"
     ],
     "ignorePaths": [

--- a/scripts/release-demo-frontend.sh
+++ b/scripts/release-demo-frontend.sh
@@ -225,9 +225,17 @@ build_frontend() {
         exit 1
     }
 
+    local cognito_domain cognito_client_id
+    cognito_domain=$(aws ssm get-parameter --name "/${ENV_NAME}/${SERVICE_NAME}/CognitoDomain" --query "Parameter.Value" --output text 2>/dev/null || echo "")
+    cognito_client_id=$(aws ssm get-parameter --name "/${ENV_NAME}/${SERVICE_NAME}/CognitoSpaClientId" --query "Parameter.Value" --output text 2>/dev/null || echo "")
+
     log_info "Building with VITE_API_URL=$VITE_API_URL..."
-    echo "VITE_API_URL=$VITE_API_URL" > "$build_dir/.env"
-    echo "VITE_GA_MEASUREMENT_ID=$GA_MEASUREMENT_ID" >> "$build_dir/.env"
+    {
+        echo "VITE_API_URL=$VITE_API_URL"
+        echo "VITE_GA_MEASUREMENT_ID=$GA_MEASUREMENT_ID"
+        echo "VITE_COGNITO_DOMAIN=$cognito_domain"
+        echo "VITE_COGNITO_CLIENT_ID=$cognito_client_id"
+    } > "$build_dir/.env"
     (cd "$build_dir" && npm run build --silent) || {
         log_error "npm run build failed"
         exit 1

--- a/scripts/release-demo-frontend.sh
+++ b/scripts/release-demo-frontend.sh
@@ -226,8 +226,20 @@ build_frontend() {
     }
 
     local cognito_domain cognito_client_id
-    cognito_domain=$(aws ssm get-parameter --name "/${ENV_NAME}/${SERVICE_NAME}/CognitoDomain" --query "Parameter.Value" --output text 2>/dev/null || echo "")
-    cognito_client_id=$(aws ssm get-parameter --name "/${ENV_NAME}/${SERVICE_NAME}/CognitoSpaClientId" --query "Parameter.Value" --output text 2>/dev/null || echo "")
+    local cognito_domain_param="/${ENV_NAME}/${SERVICE_NAME}/CognitoDomain"
+    local cognito_client_id_param="/${ENV_NAME}/${SERVICE_NAME}/CognitoSpaClientId"
+    cognito_domain=$(aws ssm get-parameter --region "$AWS_REGION" \
+        --name "$cognito_domain_param" --query "Parameter.Value" --output text) || {
+        log_error "Failed to fetch Cognito domain from SSM ($cognito_domain_param in $AWS_REGION)"
+        log_error "Shipping the demo frontend without Cognito config would silently disable auth."
+        exit 1
+    }
+    cognito_client_id=$(aws ssm get-parameter --region "$AWS_REGION" \
+        --name "$cognito_client_id_param" --query "Parameter.Value" --output text) || {
+        log_error "Failed to fetch Cognito SPA client ID from SSM ($cognito_client_id_param in $AWS_REGION)"
+        log_error "Shipping the demo frontend without Cognito config would silently disable auth."
+        exit 1
+    }
 
     log_info "Building with VITE_API_URL=$VITE_API_URL..."
     {
@@ -264,7 +276,7 @@ invalidate_cloudfront() {
     log_info "Fetching CloudFront distribution ID from SSM..."
 
     local distribution_id
-    distribution_id=$(aws ssm get-parameter \
+    distribution_id=$(aws ssm get-parameter --region "$AWS_REGION" \
         --name "$SSM_DISTRIBUTION_ID" \
         --query "Parameter.Value" \
         --output text 2>/dev/null) || {


### PR DESCRIPTION
##### Description of Change

Follow-up to #899. After that PR merged, the `demo-lif-mdr-cognito` stack was deployed (User Pool `us-east-1_tUBUfFEbI`, SPA client `6c93b0usljvbi5o12j0lv4pq3u`, hosted UI `demo-mdr-selfserve.auth.us-east-1.amazoncognito.com`) and the `/demo/mdr/Cognito{UserPoolId,SpaClientId,Domain}` SSM params are populated. Two small repo changes finish the promotion:

- **`cloudformation/demo-lif-mdr-api.params`** — produced by `./scripts/release-demo.sh --apply`. Bumps `ImageUrl` from the stale `2026-03-30-20-00-57-171376d` tag (pre-Cognito) to `2026-04-17-01-26-19-64a2b7f` (post-merge commit containing Cognito validation + AuthContext UX fix). Only this file changes; all 32 other demo services are already current.
- **`scripts/release-demo-frontend.sh`** — mirrors the dev GHA fix in `05f8642`. Reads `/demo/mdr/CognitoDomain` and `/demo/mdr/CognitoSpaClientId` from SSM at build time and writes them into the `.env` consumed by Vite. Without this, a demo frontend release would ship a Cognito-disabled bundle even with the new source code.

##### Related Issues

Follow-up to #899 / #882

##### Type of Change

- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] CloudFormation/SAM templates
- [x] Documentation (scripts)

##### Testing

Post-merge deploy sequence on demo:
1. `./aws-deploy.sh -s demo --only-stack demo-lif-mdr-api` — re-renders task def with the now-populated Cognito SSM params and pulls the new image tag.
2. `./scripts/release-demo-frontend.sh main --apply` — builds the frontend from `main` with the Cognito env vars resolved from SSM.
3. Manual: register on `https://mdr.demo.lif.unicon.net/login` → Hosted UI → verify email → callback → authenticated API calls.

##### Additional Notes

Demo Cognito stack itself is already deployed. This PR only updates repo state so the next deploy cycle picks up the right image + build config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)