### PR TITLE
Issue #883: Cut over MDR demo data to tenant_lif_team (Phase 2 PR 3)

### DIFF
--- a/cloudformation/cognito-selfserve.yml
+++ b/cloudformation/cognito-selfserve.yml
@@ -118,6 +118,21 @@ Resources:
         RefreshToken: days
 
   # ---------------------------------------------------------------------------
+  # LIF team group — routes to tenant_lif_team when tenant routing is enabled
+  # (issue #883 PR 3). Group membership is NOT managed by CloudFormation:
+  # the LIF team adds themselves via the Cognito console or Admin API as a
+  # one-time post-deploy step. Evaluators auto-join their own eval-{username}
+  # group via the post-confirmation Lambda and never land here.
+  # ---------------------------------------------------------------------------
+  LifTeamGroup:
+    Type: AWS::Cognito::UserPoolGroup
+    Properties:
+      UserPoolId: !Ref UserPool
+      GroupName: lif-team
+      Description: Internal LIF team — MDR API routes their requests to tenant_lif_team.
+      Precedence: 10
+
+  # ---------------------------------------------------------------------------
   # Post-Confirmation Lambda — creates a Cognito group for each new user
   # ---------------------------------------------------------------------------
   PostConfirmationLambda:

--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -8,6 +8,14 @@
     "ParameterValue": "false"
   },
   {
+    "ParameterKey": "EnableTenantRouting",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "TenantServiceSchema",
+    "ParameterValue": "tenant_lif_team"
+  },
+  {
     "ParameterKey": "DomainNames",
     "ParameterValue": "mdr-api.demo.lif.unicon.net"
   },

--- a/cloudformation/dev-lif-mdr-api.params
+++ b/cloudformation/dev-lif-mdr-api.params
@@ -8,6 +8,14 @@
     "ParameterValue": "false"
   },
   {
+    "ParameterKey": "EnableTenantRouting",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "TenantServiceSchema",
+    "ParameterValue": "tenant_lif_team"
+  },
+  {
     "ParameterKey": "DomainNames",
     "ParameterValue": "mdr-api.dev.lif.unicon.net"
   },

--- a/cloudformation/lif-mdr-api-taskdef-includes.yml
+++ b/cloudformation/lif-mdr-api-taskdef-includes.yml
@@ -17,6 +17,12 @@ Environment:
   - Name: MDR__AUTH__COGNITO_REGION
     Value:
       Fn::Sub: "${AWS::Region}"
+  - Name: MDR__TENANT_ROUTING__ENABLED
+    Value:
+      Ref: EnableTenantRouting
+  - Name: MDR__TENANT_ROUTING__SERVICE_SCHEMA
+    Value:
+      Ref: TenantServiceSchema
 Secrets:
   - Name: POSTGRESQL_USER
     ValueFrom: 

--- a/cloudformation/service.yml
+++ b/cloudformation/service.yml
@@ -220,6 +220,30 @@ Parameters:
       - 'false'
     Description: Enable Cognito authentication for this service
 
+  EnableTenantRouting:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >
+      Issue #883 Phase 2. When true, the MDR API resolves each request to
+      a tenant_{group} PG schema and issues SET search_path per session.
+      When false, requests hit the default search_path (public) exactly
+      as they did before #883 — provides a one-switch rollback if the
+      cutover needs to be reversed.
+
+  TenantServiceSchema:
+    Type: String
+    Default: public
+    Description: >
+      Issue #883 Phase 2. When tenant routing is enabled, this is the
+      PG schema that X-API-Key service callers (GraphQL, Semantic Search,
+      Translator, Cognito post-confirm Lambda) route to, and the fallback
+      for Cognito users whose group doesn't resolve to a tenant. Defaults
+      to public to match the flag-off behavior; set to tenant_lif_team
+      in dev/demo params once the cutover lands.
+
   EcsLaunchType:
     Type: String
     Default: FARGATE

--- a/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.3__tenant_lif_team_schema.sql
+++ b/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.3__tenant_lif_team_schema.sql
@@ -1,0 +1,23 @@
+-- Issue #883 Phase 2 PR 3: Cut over — provision tenant_lif_team schema.
+--
+-- This is the destination for the internal "lif-team" Cognito group (added
+-- to the Cognito stack in this PR) and the default target for API-key
+-- service callers once MDR__TENANT_ROUTING__ENABLED is flipped to true.
+--
+-- The clone copies every public row into tenant_lif_team, so the team's
+-- workspace carries the full current demo data model. Public is left
+-- intact: the feature flag can be flipped back to false for emergency
+-- rollback, at which point traffic resumes hitting public directly. A
+-- later cleanup migration may empty public's data tables once we're
+-- confident in the cutover — not this PR.
+--
+-- Idempotent per the CLAUDE.md "MDR Schema Migrations (V1.2+)" convention:
+-- safe to re-run after local `docker compose down -v` cycles.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'tenant_lif_team') THEN
+        PERFORM public.clone_lif_schema('tenant_lif_team', TRUE);
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

Final piece of the #883 Phase 2 cutover. Provisions the `tenant_lif_team` PostgreSQL schema, adds the matching Cognito group, and flips `MDR__TENANT_ROUTING__ENABLED` to `true` in dev and demo params. After this lands and deploys, the LIF-internal team and all `X-API-Key` service callers route to `tenant_lif_team` via `SET search_path`; `public` is left intact as the rollback target.

This is the only PR in the #883 stack that actually changes runtime behavior. PRs #901, #902, #903, #904, #905 all shipped as dead-code-behind-a-flag or pure infra. This one flips the flag.

Sibling PR (parallel, not stacked): #907 (docs structural guide).

## What changes

**Flyway V1.3 — `V1.3__tenant_lif_team_schema.sql`:**

```sql
DO $$
BEGIN
    IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'tenant_lif_team') THEN
        PERFORM public.clone_lif_schema('tenant_lif_team', TRUE);
    END IF;
END $$;
```

Calls the `clone_lif_schema` function from PR 4a with `include_data=TRUE` so the new schema carries the full current demo data model. Idempotent per the migration convention documented in `CLAUDE.md` § "MDR Schema Migrations" — safe to re-run after `docker compose down -v` cycles.

**CloudFormation:**

- `service.yml` — two new parameters with safe defaults: `EnableTenantRouting` (default `'false'`) and `TenantServiceSchema` (default `'public'`). Any stack that doesn't explicitly opt in stays at flag-off behavior.
- `lif-mdr-api-taskdef-includes.yml` — wires the parameters into `MDR__TENANT_ROUTING__ENABLED` and `MDR__TENANT_ROUTING__SERVICE_SCHEMA` env vars via `Ref`.
- `dev-lif-mdr-api.params` and `demo-lif-mdr-api.params` — opt in with `EnableTenantRouting=true`, `TenantServiceSchema=tenant_lif_team`.

**Cognito:**

- `cognito-selfserve.yml` — new `LifTeamGroup` (UserPoolGroup, Precedence 10). Group membership is NOT managed by CloudFormation — LIF team adds themselves via the Cognito console as a one-time post-deploy step. Self-serve evaluators auto-join their own `eval-{username}` group via the post-confirmation Lambda and never land here.

## Rollout order (per env)

1. Apply V1.3 via the Flyway flow → creates `tenant_lif_team`, no behavior change since flag is still off.
2. Verify `\dn tenant_lif_team` in env Aurora.
3. Redeploy `*-lif-mdr-cognito` stack so `LifTeamGroup` exists.
4. Cognito console: add LIF team members to the `lif-team` group.
5. Redeploy `*-lif-mdr-api` stack — flag flips to `true`, requests start routing through `tenant_lif_team`.
6. Verify CloudWatch logs show `SET search_path TO "tenant_lif_team"` on subsequent requests.

## Rollback plan

Redeploy MDR API with `EnableTenantRouting=false` in the param file. Public schema still has all data; traffic resumes hitting public instantly. No data migration required.

A later cleanup migration may empty public's data tables once we're confident — **not this PR**.

## Test plan

- [x] `bash -n` syntax check on the migration SQL via PG-aware regex parse (V1.3 SQL is short and validated by inspection — full Flyway run is part of the rollout).
- [x] Pre-commit pass: cspell, ruff, ty, pytest. (No code changes; only SQL + YAML + JSON params.)
- [x] CloudFormation YAML parses with intrinsic-aware loader.
- [x] `dev-lif-mdr-api.params` and `demo-lif-mdr-api.params` are valid JSON.
- [ ] **End-to-end requires AWS deploy.** Smoke checklist after merge:
  1. `aws-deploy.sh dev --only-stack dev-mdr-database` (or the SAM reset flow) → applies V1.3.
  2. `psql -h <dev-aurora> -U lif -d LIF -c '\dn tenant_lif_team'` → expect schema present.
  3. `psql ... -c "SELECT count(*) FROM tenant_lif_team.\"DataModels\""` → expect non-zero row count matching public.
  4. `aws-deploy.sh dev --only-stack dev-lif-mdr-cognito` → `LifTeamGroup` created.
  5. Add LIF team members to `lif-team` group via Cognito console.
  6. `aws-deploy.sh dev --only-stack dev-lif-mdr-api` → flag on.
  7. Hit any GET endpoint with `X-API-Key` and check CloudWatch for `SET search_path TO "tenant_lif_team"`.
  8. Sanity-check GraphQL/translator/semantic-search service-to-service calls still work (they go through MDR API which now routes to `tenant_lif_team`).

## Out of scope / follow-ups

- **PR 5** — Cross-tenant isolation integration tests. Needs PR 3 deployed so there's a real multi-tenant environment to exercise.
- **PR 6 (optional)** — Personalize seed data (rename OrgLIF/ContributorOrganization to registrant org).
- **Public cleanup** — Truncating public's data tables after we're confident in the cutover. Separate, smaller PR; defer until at least a full deploy cycle has run with the flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)