### PR TITLE
docs: README in MDR-side component bricks

### DIFF
--- a/components/lif/mdr_auth/README.md
+++ b/components/lif/mdr_auth/README.md
@@ -1,0 +1,25 @@
+# `mdr_auth` — Component
+
+Authentication for the LIF Metadata Repository API. Provides the FastAPI middleware that handles three principal types in one place:
+
+- **Service API-keys** — internal services (GraphQL, Translator, Semantic Search, Post-Confirmation Lambda) authenticate with `X-API-Key`.
+- **Cognito JWT** — end users from the self-serve flow, validated against the user pool's JWKS.
+- **Legacy HS256 JWT** — pre-Cognito callers (demo accounts, etc.), validated against the local shared secret.
+
+The middleware also resolves `request.state.tenant_schema` per request based on the caller's `cognito:groups` claim and an optional workspace-selection cookie — see [`docs/design/cross-cutting/self-serve-tenant-auth.md`](../../../docs/design/cross-cutting/self-serve-tenant-auth.md).
+
+## Public surface
+
+```python
+from lif.mdr_auth import (
+    AuthMiddleware,
+    create_access_token, create_refresh_token, decode_jwt,
+)
+```
+
+`core.py` additionally exposes Cognito-side helpers (`decode_cognito_jwt`, `_get_cognito_jwk_client`) and config constants used by tests.
+
+Phase 3 of issue #884 adds `workspace_cookie.py` (HMAC-signed workspace selection cookie) and `invite_token.py` (signed invite tokens for tenant sharing). Those land alongside the corresponding endpoint PRs (#914, #918).
+
+## Used by
+- `bases/lif/mdr_restapi` (mounts `AuthMiddleware`)

--- a/components/lif/mdr_client/README.md
+++ b/components/lif/mdr_client/README.md
@@ -1,0 +1,35 @@
+# `mdr_client` — Component
+
+HTTP client for the LIF Metadata Repository API. Used by every non-MDR service that needs to fetch the OpenAPI schema, data-model definitions, or transformation rules at startup or runtime.
+
+Sends `X-API-Key` from the `LIF_MDR_API_AUTH_TOKEN` env var on every request when configured.
+
+## Public surface
+
+```python
+from lif.mdr_client import (
+    # Config-based (preferred)
+    load_openapi_schema, fetch_schema_from_mdr,
+    # File fallback
+    get_openapi_lif_data_model_from_file,
+    # Legacy env-var based functions
+    get_openapi_lif_data_model, get_openapi_lif_data_model_sync,
+    get_data_model_schema, get_data_model_schema_sync,
+    get_data_model_transformation,
+    # Exceptions
+    MDRClientException, MDRConfigurationError,
+)
+```
+
+`load_openapi_schema(config)` is the preferred entrypoint — it takes a `LIFSchemaConfig` and returns `(schema_dict, source)` where `source` is `"mdr"` or `"file"`. Callers should pass `LIFSchemaConfig.from_environment()` rather than threading individual env vars through.
+
+**No silent fallback in production:** if MDR is configured but unreachable, `load_openapi_schema` fails with a clear error. Use `USE_OPENAPI_DATA_MODEL_FROM_FILE=true` (dev only) to opt into the bundled-file path.
+
+## Bundled file
+
+`resources/openapi_constrained_with_interactions.json` is the snapshot used by the file-fallback path. Kept in sync with MDR's V1.1 baseline; not the source of truth.
+
+## Used by
+- `bases/lif/api_graphql` — loads schema at startup, regenerates GraphQL types from it
+- `components/lif/schema_state_manager` — wraps `load_openapi_schema` for services that need refresh + sync/async access
+- `components/lif/translator` — fetches transformation definitions

--- a/components/lif/mdr_dto/README.md
+++ b/components/lif/mdr_dto/README.md
@@ -1,0 +1,26 @@
+# `mdr_dto` — Component
+
+Pydantic request/response models (DTOs) for the MDR API. One file per endpoint group; each defines the wire format for that group's create/update/list/get endpoints.
+
+## Layout
+
+| File | Endpoint group |
+|---|---|
+| `attribute_dto.py` | `/attributes` |
+| `datamodel_dto.py` | `/datamodels` |
+| `datamodel_constraints_dto.py` | `/datamodel_constraints` |
+| `entity_dto.py` | `/entities` |
+| `entity_association_dto.py` | `/entity_associations` |
+| `entity_attribute_association_dto.py` | `/entity_attribute_associations` |
+| `inclusion_dto.py` | `/inclusions` |
+| `import_export_dto.py` | `/import_export` |
+| `transformation_dto.py`, `transformation_group_dto.py` | `/transformation_groups` |
+| `value_mapping_dto.py` | `/value_mappings` |
+| `valueset_dto.py`, `value_set_values_dto.py` | `/value_sets`, `/value_set_values` |
+
+Models follow the Pydantic v2 conventions used elsewhere (`from_attributes=True` instead of legacy `from_orm`; `model_dump` instead of `dict`).
+
+## Used by
+- `bases/lif/mdr_restapi` — every endpoint module imports its matching DTOs from here
+
+This component is MDR-internal. Other services that need MDR data should call the MDR API via `mdr_client`, not import these DTOs directly — the DTOs are wire shapes, not stable inter-service contracts.

--- a/components/lif/mdr_services/README.md
+++ b/components/lif/mdr_services/README.md
@@ -1,0 +1,33 @@
+# `mdr_services` — Component
+
+Business logic for the MDR API. Each `*_service.py` module owns a slice of MDR functionality and is invoked by the matching endpoint module in `bases/lif/mdr_restapi/`. Services depend on `mdr_dto` for shapes and `mdr_utils` for session/config plumbing, but never on FastAPI directly — they're plain async functions and classes.
+
+## Layout
+
+| File | Concern |
+|---|---|
+| `attribute_service.py` | Scalar attributes within entities |
+| `datamodel_service.py` | LIF data models (Base LIF, Org LIF, target transformation models) |
+| `datamodel_constraints_service.py` | Constraint rules per model |
+| `entity_service.py` | Entity definitions |
+| `entity_association_service.py` | Entity-to-entity relationships |
+| `entity_attribute_association_service.py` | Attribute membership in entities |
+| `helper_service.py` | Cross-cutting helpers used by multiple services |
+| `import_export_service.py` | Bulk import/export of MDR content |
+| `inclusions_service.py` | Reusable attribute groups (Contact, Address, etc.) |
+| `jinja_helper_service.py`, `jinja_translation_service.py` | Jinja-based template + translation generation |
+| `schema_generation_service.py` | Builds OpenAPI schemas from MDR content (the schema `mdr_client` fetches) |
+| `schema_upload_service.py` | Accepts a new schema upload and persists it |
+| `search_service.py` | MDR-wide full-text search |
+| `tag_service.py` | Tagging for entities/attributes |
+| `tenant_service.py` | Self-serve tenant lifecycle (#883/#884): `provision_tenant`, exception types |
+| `transformation_service.py` | JSONata transformation groups, source→target mappings |
+| `value_mapping_service.py` | Code/value crosswalks |
+| `valueset_service.py`, `value_set_values_service.py` | Strict + extensible enums |
+
+## Used by
+- `bases/lif/mdr_restapi` — every endpoint module imports its matching service
+
+## See also
+- [`docs/design/cross-cutting/self-serve-tenant-auth.md`](../../../docs/design/cross-cutting/self-serve-tenant-auth.md) for what `tenant_service.provision_tenant` is doing under the hood (`clone_lif_schema` Postgres function).
+- [`docs/specs/data-model-rules.md`](../../../docs/specs/data-model-rules.md) for the schema rules these services enforce.

--- a/components/lif/mdr_utils/README.md
+++ b/components/lif/mdr_utils/README.md
@@ -1,0 +1,31 @@
+# `mdr_utils` — Component
+
+Utility plumbing for the MDR API: settings, database setup, logging, pagination, SQL helpers. MDR-internal — other services have their own utility modules (`lif.logging`, `lif.lif_schema_config`, etc.) and shouldn't import from here.
+
+## Layout
+
+| File | What it provides |
+|---|---|
+| `config.py` | `Settings` (`pydantic_settings.BaseSettings`) + `get_settings()` — all MDR env vars including CORS, auth, tenant routing, workspace cookie, invite tokens |
+| `database_setup.py` | SQLAlchemy async engine, `get_session()` dependency, lifecycle management |
+| `logger_config.py` | `get_logger(__name__)` — MDR's logger format (note: other services use `lif.logging` with a slightly different format) |
+| `collection_utils.py` | `convert_csv_to_set` and similar CSV-string parsing helpers |
+| `error_handling.py` | Common HTTPException helpers and error envelope shapes |
+| `pagination_util.py` | Pagination helpers for list endpoints |
+| `sql_util.py`, `sql_config.yaml` | SQL query templates and config-driven query construction |
+| `yaml_util.py` | YAML loader helpers (used by SQL config and seed-data loaders) |
+
+## Public surface
+
+```python
+from lif.mdr_utils.config import get_settings
+from lif.mdr_utils.database_setup import get_session
+from lif.mdr_utils.logger_config import get_logger
+```
+
+These three are the most-used entrypoints.
+
+## Used by
+- `bases/lif/mdr_restapi` — every endpoint, plus `core.py` (CORS / app setup)
+- `components/lif/mdr_services` — services pull `get_session` and `get_logger`
+- `components/lif/mdr_auth` — pulls `get_settings`, `get_logger`, `convert_csv_to_set`

--- a/cspell.json
+++ b/cspell.json
@@ -156,6 +156,8 @@
         "pyenv",
         "pyflow",
         "pyjwt",
+        "Pydantic",
+        "pydantic",
         "pymysql",
         "pypa",
         "pypackages",


### PR DESCRIPTION
## Summary
Adds short READMEs to the five MDR-side components: `mdr_auth`, `mdr_client`, `mdr_dto`, `mdr_services`, `mdr_utils`. Each follows the same shape: purpose, public surface, file layout (where the brick has many sub-modules), and the list of consumers.

`mdr_services` and `mdr_dto` each get an at-a-glance table of files → endpoint groups so readers don't have to open 20 modules to find the right one.

## Why
Tier 1 README sweep, batch 2 of ~4 (after PR #922's bases). Reviewer-free docs PR.

## Test plan
- [x] `uv run pre-commit run cspell --files components/lif/mdr_*/README.md` passes
- [ ] Spot-check the "Used by" lists after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)