### PR TITLE
docs: README in query/orchestration component bricks

### DIFF
--- a/components/lif/orchestrator_clients/README.md
+++ b/components/lif/orchestrator_clients/README.md
@@ -1,0 +1,24 @@
+# `orchestrator_clients` — Component
+
+Client implementations the [`orchestrator_service`](../orchestrator_service/) uses to talk to actual orchestration backends. The factory pattern lets a single orchestrator HTTP service drive different backends without code changes in the service layer.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `core.py` | Re-exports for the brick's public surface |
+| `factory.py` | `OrchestratorFactory`, `OrchestratorNotFoundError` — chooses a client by backend id |
+| `dagster.py` | Dagster-specific client implementation |
+
+Today Dagster is the only backend in tree. Adding another (Airflow, Prefect, etc.) means a new sibling file plus a factory registration.
+
+## Public surface
+
+```python
+from lif.orchestrator_clients.factory import OrchestratorFactory, OrchestratorNotFoundError
+```
+
+The factory looks up a client by id and returns an instance configured against the service's settings.
+
+## Used by
+- `components/lif/orchestrator_service` — `service.py` and `core.py` use the factory to obtain a client

--- a/components/lif/orchestrator_service/README.md
+++ b/components/lif/orchestrator_service/README.md
@@ -1,0 +1,23 @@
+# `orchestrator_service` — Component
+
+Business logic for the LIF Orchestrator. Fans out a query plan across the configured data-source adapters, collects responses, runs translations, and merges results back into a unified `OrchestratorJob`.
+
+## Public surface
+
+```python
+from lif.orchestrator_service.service import OrchestratorService
+from lif.orchestrator_service import core
+```
+
+`OrchestratorService` is the entrypoint — the orchestrator HTTP base instantiates one at app startup (in its lifespan handler) and reuses it across requests.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `core.py` | Imports / re-exports surface; small helpers |
+| `service.py` | `OrchestratorService` — submits jobs, tracks state, dispatches to adapters via `orchestrator_clients` |
+
+## Used by
+- `bases/lif/orchestrator_restapi` — mounts the service behind HTTP endpoints
+- `components/lif/orchestrator_clients` — clients call back into the service when reporting job results

--- a/components/lif/query_cache_read/README.md
+++ b/components/lif/query_cache_read/README.md
@@ -1,0 +1,5 @@
+# `query_cache_read` — Component (stub)
+
+Empty placeholder brick. `core.py` has no content.
+
+Intended to host the future read-side interface for the Query Cache — once the cache's MongoDB-specific code in [`query_cache_service`](../query_cache_service/) is split into an abstract read protocol plus per-store implementations ([`query_cache_read_store_mongodb`](../query_cache_read_store_mongodb/), [`query_cache_read_store_in_memory`](../query_cache_read_store_in_memory/)). Until that refactor lands, this brick is scaffolding only — the cache still talks to Mongo directly via `query_cache_service`.

--- a/components/lif/query_cache_read_store_in_memory/README.md
+++ b/components/lif/query_cache_read_store_in_memory/README.md
@@ -1,0 +1,5 @@
+# `query_cache_read_store_in_memory` — Component (stub)
+
+Empty placeholder brick. `core.py` has no content.
+
+Intended to host an in-memory implementation of the future cache read interface (see [`query_cache_read`](../query_cache_read/)). Useful for tests and local development once the MongoDB coupling in [`query_cache_service`](../query_cache_service/) is factored out. Until then, this brick is scaffolding only.

--- a/components/lif/query_cache_read_store_mongodb/README.md
+++ b/components/lif/query_cache_read_store_mongodb/README.md
@@ -1,0 +1,5 @@
+# `query_cache_read_store_mongodb` — Component (stub)
+
+Empty placeholder brick. `core.py` has no content.
+
+Intended to host the MongoDB implementation of the future cache read interface (see [`query_cache_read`](../query_cache_read/)). The MongoDB-specific code currently lives in [`query_cache_service`](../query_cache_service/); the planned refactor would migrate it here. Until then, this brick is scaffolding only.

--- a/components/lif/query_cache_service/README.md
+++ b/components/lif/query_cache_service/README.md
@@ -1,0 +1,25 @@
+# `query_cache_service` — Component
+
+Core cache logic for the LIF Query Cache. Implements the four cache operations (`query`, `update`, `add`, `save`) against MongoDB, including the MongoDB-specific update operator construction (`$set` / `$push` / etc.) that handles LIF's array-heavy data model.
+
+## Public surface
+
+```python
+from lif.query_cache_service.core import query, update, add, save
+```
+
+| Function | Purpose |
+|---|---|
+| `async query(lif_query) -> List[LIFRecord]` | Read records matching a `LIFQuery` filter; projects selected fields |
+| `async update(lif_update) -> LIFRecord` | Apply a `LIFUpdate` (filter + input pairs) to one record |
+| `async add(lif_record) -> LIFRecord` | Insert a fresh `LIFRecord` |
+| `async save(lif_query_filter, lif_fragments)` | Bulk merge fragments into a record selected by filter |
+
+Helper functions (`clean_projection`, `extract_filter`, `build_mongo_update_ops`, `format_push_ops`, `extract_updated_fields`) are internal but exported for tests.
+
+## Implementation notes
+
+MongoDB is hard-coded today. The empty stub bricks [`query_cache_read`](../query_cache_read/), [`query_cache_read_store_in_memory`](../query_cache_read_store_in_memory/), and [`query_cache_read_store_mongodb`](../query_cache_read_store_mongodb/) are scaffolding for a future refactor that would extract the read interface and swap in alternative stores. Until that lands, this component owns the Mongo coupling directly.
+
+## Used by
+- `bases/lif/query_cache_restapi` — mounts these functions as HTTP endpoints

--- a/components/lif/query_planner_service/README.md
+++ b/components/lif/query_planner_service/README.md
@@ -1,0 +1,35 @@
+# `query_planner_service` — Component
+
+Business logic for the LIF Query Planner. Decides *how* to fulfill a `LIFQuery`: which information sources to hit, what comes from cache vs. fresh orchestration, which translations to apply. Manages in-memory job state for async queries.
+
+## Public surface
+
+```python
+from lif.query_planner_service.core import (
+    LIFQueryPlannerService,
+    LIFQueryPlannerJob,
+    prune_job_store,
+    add_job_to_store,
+    # ...
+)
+from lif.query_planner_service.datatypes import (
+    LIFQueryPlannerConfig,
+    LIFQueryPlannerInfoSourceConfig,
+)
+from lif.query_planner_service import util
+```
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `core.py` | `LIFQueryPlannerService` (the planner), `LIFQueryPlannerJob` (async job state), in-memory job store helpers |
+| `datatypes.py` | Planner-specific config models (`LIFQueryPlannerConfig`, `LIFQueryPlannerInfoSourceConfig`) |
+| `util.py` | Cross-cutting helpers used by `core` |
+
+## Configuration
+
+The planner is configured per-organization via YAML — `deployments/*/information_sources_config*.yml`. One planner instance runs per org in the reference deployment.
+
+## Used by
+- `bases/lif/query_planner_restapi` — mounts the service behind HTTP endpoints


### PR DESCRIPTION
## Summary
Tier 1 README sweep, batch 3 of 4. Adds short READMEs to seven query- and orchestration-side components, following the same template as PRs #922 (bases) and #923 (MDR components).

| Component | Notes |
|---|---|
| `query_cache_service` | The actual cache logic; documents the four operations + MongoDB coupling |
| `query_cache_read` | **Stub** (empty `core.py`) — placeholder for future read interface |
| `query_cache_read_store_in_memory` | **Stub** — future in-memory implementation |
| `query_cache_read_store_mongodb` | **Stub** — future MongoDB implementation |
| `query_planner_service` | `LIFQueryPlannerService` + async job store |
| `orchestrator_service` | `OrchestratorService` entrypoint |
| `orchestrator_clients` | Factory pattern; Dagster is the only backend today |

The three empty stub bricks now each have a README explaining what they're scaffolding for, so a reader doesn't have to guess why an empty `core.py` is registered as a brick.

## Test plan
- [x] `uv run pre-commit run cspell --files <new READMEs>` passes — no new dictionary words needed
- [ ] Spot-check the "Used by" lists after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)