### PR TITLE
docs: projects/ README spot-check + fill missing-dir gaps

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -22,7 +22,7 @@ These directories correspond to typical Python project structures, including a `
 ## Example Structure
 
 <pre lang="markdown"> <code> 
-frontends/  
+projects/  
 ├── lif_query_cache_api/  
 │ ├── pyproject.toml # Project metadata and dependencies  
 │ ├── Dockerfile # Container build instructions  

--- a/projects/dagster_plus_hybrid/example_deployment/README.md
+++ b/projects/dagster_plus_hybrid/example_deployment/README.md
@@ -1,0 +1,13 @@
+# `example_deployment/` — Dagster+ Hybrid reference deployments
+
+Reference deployment configurations for running Dagster+ Hybrid agents in customer-controlled infrastructure. Each subdirectory targets a specific platform.
+
+## Subdirectories
+
+| Path | Target |
+|---|---|
+| [`aws_fargate/`](aws_fargate/) | AWS ECS Fargate deployment template |
+
+## Status
+
+Dagster+ Hybrid itself is being decommissioned in favor of Dagster OSS on AWS — see [`../README.md`](../README.md). These deployment examples are kept around for historical reference and may be removed when the decommission completes.

--- a/projects/lif_identity_mapper_mariadb/sample_data/README.md
+++ b/projects/lif_identity_mapper_mariadb/sample_data/README.md
@@ -1,0 +1,15 @@
+# `sample_data/` — Identity Mapper seed datasets
+
+Per-organization seed data for the Identity Mapper MariaDB instance. Each subdirectory holds the mappings needed for one demo org partition; the `SEED_DATA_KEY` env var on the container selects which one to load.
+
+## Subdirectories
+
+| Partition | Purpose |
+|---|---|
+| `advisor-demo-org1/` | Matt, Renee, Sarah, Tracy — org1's native users |
+| `advisor-demo-org2/` | Alan, Jenna, Sarah, Tracy — org2's native users |
+| `advisor-demo-org3/` | Alan, Jenna, Matt, Renee — org3's native users |
+
+The cross-org duplication (e.g., Sarah in both org1 and org2) is intentional — it exercises the identity-mapping layer when the same person needs to be resolved across orgs with different identifier conventions.
+
+For the broader test-user matrix (including async ingestion flows), see CLAUDE.md § "Integration Tests."

--- a/projects/lif_mdr_api/README.md
+++ b/projects/lif_mdr_api/README.md
@@ -1,33 +1,63 @@
 # LIF Metadata Repository (MDR) API
 
-The **Metadata Repository (MDR)** is a key component of LIF. It provides the capabilities to maintain the *LIF data model* in all of its iterations---including an *organization-specific LIF data model* and *partner LIF data models.* The **MDR** and *LIF data model* will be maintained by the steward or organization governing LIF.
+The **Metadata Repository (MDR)** is LIF's control-plane service. It holds the LIF data model (Base LIF + per-organization models), transformation definitions, value sets, and — since #883 — per-tenant routing configuration. Most other LIF services load their schema and transformation rules from here at startup.
 
-The **MDR** is a standalone component that serves as the LIF system of record. It is where individuals from implementing organizations maintain their *organization-specific LIF data model* and *partner LIF data models* through a graphical user interface.
+Composed from `bases/lif/mdr_restapi/` + the `mdr_*` components. See [`../../bases/lif/mdr_restapi/README.md`](../../bases/lif/mdr_restapi/README.md) for the endpoint-group map and [`../../docs/design/cross-cutting/self-serve-tenant-auth.md`](../../docs/design/cross-cutting/self-serve-tenant-auth.md) for the multi-tenant story.
 
-Additionally, the **MDR** provides the capability for the organization to maintain source data model(s) and mappings to transform data into a structure aligned to the *organization-specific LIF data model*.
+## Components
 
-The **MDR** will enable the organization to define which elements of its *organization-specific LIF data model* can be shared externally as its *partner-accessible LIF data model*. As a Possible Future Roadmap Item, the **MDR** will also allow the retrieval of the *partner-accessible LIF data model* from partners that have allowed for queries via **LIF API**.
+- **Database:** Postgres, deployed separately via [`../lif_mdr_database/`](../lif_mdr_database/). Schema is managed by Flyway migrations (V1.1, V1.2, V1.3 tenant cutover, V1.4 `clone_lif_schema`).
+- **Frontend:** React/TypeScript UI lives at [`../../frontends/mdr-frontend/`](../../frontends/mdr-frontend/), deployed to S3+CloudFront via `scripts/release-demo-frontend.sh`.
 
-The API is created with FastAPI and dependency management is done by UV.
+## Building
 
-## Quickstart
- - Before running the API, the DB should be up and running.
- - Copy the `mdr-api.env.example` file and rename it as `mdr-api.env` under the `projects/lif_mdr_api` folder and add/adjust the database, CORs, and auth details.
+```bash
+# Wheel build (for distribution / debugging)
+cd projects/lif_mdr_api
+bash build.sh
 
+# Docker image — uses Dockerfile2 (the canonical pattern; legacy Dockerfile retained)
+bash build-docker.sh
+```
 
-### Deployment:
-- Goto `projects/lif_mdr_api` folder and run :
-    ```
-    docker-compose up --build -d
-    ```
-- Once deployed you can see swagger at http://localhost:8012/docs#
+`Dockerfile2` is the path used by CI and reference deployments — it does a two-stage build with `uv sync` from this project's `pyproject.toml`. Any new runtime dependency must be added **to this project's `pyproject.toml`, not just the monorepo root** (see [`../../docs/operations/guides/adding-a-new-microservice.md`](../../docs/operations/guides/adding-a-new-microservice.md) for the rationale).
 
+## Configuration
 
-## Test Cases
+All settings come from environment variables, parsed by `Settings` in `components/lif/mdr_utils/config.py`. Key env vars:
 
-- This repository includes a suite of unit tests under `test/components/lif/mdr_services`. The tests use `pytest` and cover the FASTAPI services: `datamodel_service`, `entity_service`, `attribute_service`, and `schema_generation_service`. 
-- You can run the tests as such in `test/components/lif/mdr_services`:
-    - `pytest test_attribute_service.py`
-    - `pytest test_datamodel_service.py`
-    - `pytest test_entity_service.py`
-    - `pytest test_schema_generation_service.py`
+| Env var | Purpose |
+|---|---|
+| `POSTGRESQL_*` | Database connection |
+| `MDR__AUTH__JWT_SECRET_KEY` | Signs HS256 access/refresh JWTs + workspace cookies + invite tokens |
+| `MDR__AUTH__SERVICE_API_KEY__*` | One key per internal service caller (graphql, semantic_search, translator, post_confirm, learner_data_export) |
+| `MDR__AUTH__COGNITO_*` | User pool id, region, SPA client id; empty user pool disables Cognito |
+| `MDR__TENANT_ROUTING__ENABLED` | Flip to `true` after the tenant_lif_team cutover (#883 Phase 2 PR 3) |
+| `MDR__TENANT_ROUTING__SERVICE_SCHEMA` | Fallback schema for service principals + group-less users |
+| `MDR__COOKIE__SECURE` | Set `false` for local HTTP dev; defaults to `true` for HTTPS envs |
+| `MDR__INVITE__TOKEN_MAX_AGE_SECONDS` | Invite token TTL (default 7 days) |
+
+For local development, copy `.env.example` (if present) or seed the values inline via docker-compose.
+
+## Running locally (Docker Compose)
+
+The MDR API + database are wired into [`../../deployments/advisor-demo-docker/docker-compose.yml`](../../deployments/advisor-demo-docker/docker-compose.yml). From repo root:
+
+```bash
+cd deployments/advisor-demo-docker
+docker compose up --build -d lif-mdr-database lif-mdr-api lif-mdr-app
+```
+
+Once up:
+- API + Swagger: http://localhost:8012/docs
+- Frontend: http://localhost:5173
+
+## Testing
+
+Component-level tests live under `test/components/lif/mdr_services/` and `test/components/lif/mdr_auth/`. Endpoint tests are at `test/bases/lif/mdr_restapi/`. Run from repo root:
+
+```bash
+uv run pytest test/components/lif/mdr_services/ test/components/lif/mdr_auth/ test/bases/lif/mdr_restapi/
+```
+
+Postgres-backed tests for the `clone_lif_schema` SQL function require a running database — see `test/.../test_clone_lif_schema_sql.py` for setup notes.

--- a/projects/lif_mdr_database/dataset/README.md
+++ b/projects/lif_mdr_database/dataset/README.md
@@ -1,0 +1,16 @@
+# `dataset/` — MDR database seed/init
+
+Legacy initialization SQL for the MDR Postgres database. Loaded once when the database is first brought up; subsequent schema changes flow through Flyway migrations under [`../../../sam/mdr-database/flyway/`](../../../sam/mdr-database/flyway/).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `init.sql` | Drops + recreates Postgres types and the V1.0 baseline schema. Effectively the "pre-Flyway" starting point. |
+
+## When this runs
+
+- **Local docker-compose:** `restore.sh` loads `backup.sql` first (a pg_dump snapshot of the V1.1 content), then applies every `V1.*.sql` migration via `psql`. `init.sql` is not used directly by the compose flow.
+- **Deployed envs (dev/demo):** Flyway manages the schema from V1.1 onward; `init.sql` is not used in deployed environments.
+
+See [`../README.md`](../README.md) for the broader database-management story including the Flyway flow and the idempotent-migration convention.

--- a/projects/mongodb/README.md
+++ b/projects/mongodb/README.md
@@ -1,0 +1,18 @@
+# MongoDB (LIF cache + advisor data store)
+
+Docker build for the MongoDB instances backing the LIF Query Cache and Advisor APIs. Not a Python project — `pyproject.toml` is absent on purpose; this directory only packages a configured MongoDB image plus seed-data loaders.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Image definition — base `mongo` plus seed-data and entrypoint |
+| `entrypoint.sh` | Loads `sample_data/<SEED_DATA_KEY>/` into the database on first start |
+| `build-docker.sh` | Convenience build script |
+| [`sample_data/`](sample_data/) | Seed datasets for demos + tests (per-org partitions: `advisor-demo-org1`, `-org2`, `-org3`, plus `dev-single-org`) |
+
+## Usage
+
+The reference deployments wire this image up as `mongodb-org1`, `mongodb-org2`, `mongodb-org3` in [`../../deployments/advisor-demo-docker/docker-compose.yml`](../../deployments/advisor-demo-docker/docker-compose.yml). Each picks a `SEED_DATA_KEY` matching its org partition.
+
+See [`sample_data/README.md`](sample_data/README.md) for what's in each dataset and the user-test-coverage table.


### PR DESCRIPTION
## Summary
Sweep of `projects/` READMEs. Two updates and four additions.

### Updates
- **`projects/README.md`** — typo: the example structure block said `frontends/` but should have said `projects/`
- **`projects/lif_mdr_api/README.md`** — rewrite reflecting the current state: Dockerfile2 vs legacy Dockerfile guidance, the full `MDR__*` env var matrix from #883/#884 (cookie, invite, tenant routing, Cognito), pointers to the new base README + the self-serve auth design doc, and accurate testing instructions

### New (previously-undocumented subdirs)
- **`projects/mongodb/README.md`** — top-level README for the MongoDB project (it had a `sample_data` README but none at root)
- **`projects/lif_mdr_database/dataset/README.md`** — explains the legacy `init.sql` and its relationship to the Flyway-managed flow
- **`projects/dagster_plus_hybrid/example_deployment/README.md`** — parent README for the `aws_fargate` sibling; flags the broader Dagster+ Hybrid decommission
- **`projects/lif_identity_mapper_mariadb/sample_data/README.md`** — describes the per-org seed-data partitions

### Reviewed but left alone
- `projects/lif_orchestrator_api/README.md`, `projects/lif_translator_api/README.md`, and `projects/dagster_plus_hybrid/README.md` are short but accurate — no rewrites needed
- Build-artifact directories (`dist/`, `bin/`, `.ruff_cache/`) get no README

## Test plan
- [x] `uv run pre-commit run cspell --files <changed files>` passes
- [ ] Spot-check rendering after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)