### PR TITLE
docs: Tier 8 repo-meta hygiene (CONTRIBUTING + PR template + schemas)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Thank you for your pull request. Please review the requirements below.
 
 Bug fixes and new features should be reported on the issue tracker: https://github.com/lif-initiative/lif-core/issues
 
-Contributing guide: https://github.com/lif-initiative/lif-core/blob/main/docs/CONTRIBUTING.md
+Contributing guide: https://github.com/lif-initiative/lif-core/blob/main/CONTRIBUTING.md
 Code of Conduct: https://github.com/lif-initiative/lif-core/blob/main/CODE_OF_CONDUCT.md
 -->
 
@@ -39,14 +39,17 @@ Closes # [[add Github issue number]]
 
 - [ ] bases/
 - [ ] components/
+- [ ] projects/
 - [ ] orchestrators/
 - [ ] frontends/
 - [ ] deployments/
-- [ ] CloudFormation/SAM templates
-- [ ] Database schema
+- [ ] cloudformation/ or sam/ templates
+- [ ] schemas/
+- [ ] scripts/
+- [ ] test/ or e2e/
+- [ ] Database schema (migrations)
 - [ ] API endpoints
-- [ ] Documentation
-- [ ] Testing
+- [ ] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,21 @@ changes.
 1. **Fork** the repository and clone your fork:
 
    ```bash
-   git clone https://github.com/your-username/lif-main.git
-   cd lif-main
+   git clone https://github.com/your-username/lif-core.git
+   cd lif-core
    ```
 
 2. **Install dependencies and create virtual environment**:
 
    ```bash
    uv sync
+   ```
+
+3. **Install pre-commit hooks** (lint / format / type-check / tests / cspell / commitlint run on every commit):
+
+   ```bash
+   uv run pre-commit install
+   uv run pre-commit install --hook-type commit-msg
    ```
 
 ---
@@ -135,12 +142,26 @@ Write tests that earn their keep. Every test should verify something non-obvious
 
 ## Commit Guidelines
 
-Use clear, descriptive commit messages. Conventional commit style is encouraged:
+Commit messages must reference a tracking issue and follow the format enforced by `commitlint.config.mjs`:
+
+```
+Issue #XXX: Brief description
+```
+
+For changes touching multiple issues, list them comma-separated:
+
+```
+Issue #123, Issue #456: Brief description
+```
+
+Type prefixes are encouraged in the description for readability (not required by commitlint):
 
 - `feat:` for new features
 - `fix:` for bug fixes
 - `docs:` for documentation changes
 - `refactor:` for internal changes that don't affect behavior
+
+Example: `Issue #884: feat: Add invite-link endpoints`
 
 ---
 
@@ -159,5 +180,5 @@ When contributing, please ensure:
 
 We appreciate your contributions and interest in the project!
 
-If you're not sure where to start, check out [open issues](https://github.com/your-org/your-project/issues),
+If you're not sure where to start, check out [open issues](https://github.com/LIF-Initiative/lif-core/issues),
 especially those labeled `good first issue` or `help wanted`.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,21 @@
+# `schemas/` — LIF data model source of truth
+
+Canonical JSON definition of the LIF data model and the rules every implementation must honor.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `lif-schema.json` | The LIF data model schema — entities, attributes, relationships, allowed value sets, and policy fields (`queryable`, `modifiable`, required-field rules) |
+
+## Relationship to the rest of LIF
+
+- **MDR (Metadata Repository)** is loaded from this schema and then extended by each deployer with org-specific entities. Once MDR is running, it becomes the runtime source of truth for most services — they fetch the schema from MDR (via [`lif.mdr_client`](../components/lif/mdr_client/)) rather than reading this file directly.
+- **Seed data** under `projects/mongodb/sample_data/` must validate against the schema MDR serves (which started from this file).
+- **GraphQL queries** in `components/lif/data_source_adapters/**/*.graphql` should align with this schema's entity and attribute names.
+
+See [`docs/specs/data-model-rules.md`](../docs/specs/data-model-rules.md) for the human-readable interpretation of the rules — PascalCase entities, camelCase scalars, naming conventions, required-field policies, the No Loss Capture principle, and so on.
+
+## Versioning
+
+The schema evolves via MDR's data-model versioning machinery (`/datamodels` endpoints). Changes that need to land at the file level go through normal PR review; downstream services pick them up after their next MDR refresh.


### PR DESCRIPTION
## Summary
Sweep of repo-meta docs turned up several clearly-broken items. Bundled into one fast-track docs PR.

### CONTRIBUTING.md
- Clone URL typo: `lif-main` → `lif-core`
- Added pre-commit install step (hooks won't fire on commit without it; commit-msg hook needed for commitlint)
- Commit-style section: replaced "conventional commit style is encouraged" with the **actual** `Issue #XXX: subject` format that `commitlint.config.mjs` enforces. Type prefixes remain encouraged in the description for readability
- Fixed placeholder issues URL `your-org/your-project` → real org

### .github/pull_request_template.md
- Contributing guide path: `docs/CONTRIBUTING.md` → `CONTRIBUTING.md` (it's at repo root, not under docs/)
- Project Area(s) checklist: added `projects/`, `schemas/`, `scripts/`, `test/` + `e2e/`; split cloudformation/sam from documentation; clarified docs scope

### schemas/README.md (new)
The `schemas/` dir had no README. Adds a brief one explaining `lif-schema.json` as the canonical data model file, MDR's role as runtime source of truth, and the pointer to `docs/specs/data-model-rules.md` for the rules.

## Why
Tier 8 of the post-#927 doc-tier plan. All unambiguous fixes — no judgment calls. Fast-track docs merge.

## Test plan
- [x] `uv run pre-commit run cspell` passes
- [ ] Spot-check PR template renders correctly on the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)