### PR TITLE
docs: Tier 7 stale-content fixes (auth ADR + MDR overview)

### DIFF
--- a/docs/design/adr/general/auth.md
+++ b/docs/design/adr/general/auth.md
@@ -4,7 +4,7 @@ Date: 2025-10-31
 
 ## Status
 
-Proposed
+Accepted — the unification described below shipped via `components/lif/mdr_auth` and `components/lif/api_key_auth`. The Cognito flow alluded to in the *Consequences* section was implemented as the self-serve onboarding work in issues #882, #883, #884 — see [`docs/design/cross-cutting/self-serve-tenant-auth.md`](../../cross-cutting/self-serve-tenant-auth.md) for the implemented architecture.
 
 ## Context
 
@@ -91,24 +91,24 @@ It will prepare the LIF ecosystem for additional auth flows to be introduced (Ad
 
 *Advisor API auth:*
 
-- https://github.com/LIF-Initiative/lif-main/blob/main/bases/lif/advisor_restapi/core.py
+- https://github.com/LIF-Initiative/lif-core/blob/main/bases/lif/advisor_restapi/core.py
 
 *Advisor App auth:*
 
-- https://github.com/LIF-Initiative/lif-main/blob/main/frontends/lif_advisor_app/src/components/LoginPanel.tsx
-- https://github.com/LIF-Initiative/lif-main/blob/main/frontends/lif_advisor_app/src/utils/axios.ts
-- https://github.com/LIF-Initiative/lif-main/blob/main/frontends/lif_advisor_app/src/App.tsx
+- https://github.com/LIF-Initiative/lif-core/blob/main/frontends/lif_advisor_app/src/components/LoginPanel.tsx
+- https://github.com/LIF-Initiative/lif-core/blob/main/frontends/lif_advisor_app/src/utils/axios.ts
+- https://github.com/LIF-Initiative/lif-core/blob/main/frontends/lif_advisor_app/src/App.tsx
 
 *Example Data Source API auth:*
 
-- https://github.com/LIF-Initiative/lif-main/blob/main/bases/lif/example_data_source_rest_api/core.py
+- https://github.com/LIF-Initiative/lif-core/blob/main/bases/lif/example_data_source_rest_api/core.py
 
 *MDR API auth:*
 
-- https://github.com/LIF-Initiative/lif-metadata-repository/blob/main/service/app/main.py
-- https://github.com/LIF-Initiative/lif-metadata-repository/blob/main/service/app/auth/core.py
+- https://github.com/LIF-Initiative/lif-core/blob/main/bases/lif/mdr_restapi/core.py
+- https://github.com/LIF-Initiative/lif-core/blob/main/components/lif/mdr_auth/core.py
 
 *MDR App auth:*
 
-- https://github.com/LIF-Initiative/lif-metadata-repository/blob/main/mdr-frontend/src/services/authService.ts
-- https://github.com/LIF-Initiative/lif-metadata-repository/blob/main/mdr-frontend/src/services/api.ts
+- https://github.com/LIF-Initiative/lif-core/blob/main/frontends/mdr-frontend/src/services/authService.ts
+- https://github.com/LIF-Initiative/lif-core/blob/main/frontends/mdr-frontend/src/services/api.ts

--- a/docs/overview/mdr-overview.md
+++ b/docs/overview/mdr-overview.md
@@ -64,7 +64,7 @@ Entities and attributes carry dot-path unique names (e.g., `person.contact.addre
 
 - **MDR API** — FastAPI service backed by PostgreSQL (Aurora in AWS deployments). Serves data models and mappings via REST; exports OpenAPI schemas for runtime consumption by other services.
 - **MDR Frontend** — React/TypeScript single-page app for visually defining entities, attributes, and mappings. Deployed to S3 + CloudFront in AWS environments.
-- **Authentication** — currently a small set of hardcoded demo users. Self-serve Cognito registration with per-tenant PostgreSQL schema isolation is in design (see `docs/proposals/mdr-self-serve-registration.md`).
+- **Authentication** — three principal types supported via the shared `AuthMiddleware`: internal service callers (`X-API-Key`), Cognito JWT (self-serve users), and legacy HS256 JWT (demo accounts). Self-serve registration provisions a per-tenant PostgreSQL schema on signup; tenant routing then sets `search_path` per request. See [`docs/design/cross-cutting/self-serve-tenant-auth.md`](../design/cross-cutting/self-serve-tenant-auth.md) for the implemented architecture.
 
 ## Try It
 
@@ -91,7 +91,7 @@ A suggested first walkthrough once you have access:
 - **LIF schema source of truth:** `schemas/lif-schema.json` in the repo
 - **Add a data source walkthrough:** [`docs/operations/guides/add-data-source.md`](../operations/guides/add-data-source.md) — step-by-step guide covering source schema creation, JSONata mappings, and pipeline wiring
 - **Data source adapter reference:** [`docs/operations/guides/creating-a-data-source-adapter.md`](../operations/guides/creating-a-data-source-adapter.md) — what an adapter is, how it consumes MDR schemas at runtime
-- **Self-serve registration proposal:** `docs/operations/proposals/mdr-self-serve-registration.md` — planned multi-tenant evolution with Cognito and per-tenant schema isolation *(currently untracked; will be relocated when committed)*
+- **Self-serve registration (as implemented):** [`docs/design/cross-cutting/self-serve-tenant-auth.md`](../design/cross-cutting/self-serve-tenant-auth.md) — narrative of the Cognito → schema-per-tenant → workspace selection → invite flow (issues #882/#883/#884)
 - **LIF services overview:** [`docs/overview/services-overview.md`](services-overview.md) — how MDR fits alongside the other LIF services
 
 ## Contact


### PR DESCRIPTION
## Summary
First pass at the Tier 7 stale-doc audit. Two unambiguous content fixes; bigger updates surfaced during the audit are listed below as follow-ups since they need scope judgment.

### `docs/design/adr/general/auth.md`
- **9 broken GitHub URLs fixed.** Five used `lif-main` (the repo is `lif-core`); four pointed at the retired `lif-metadata-repository` repo whose content moved into `lif-core` during the monorepo consolidation. Repointed all to current paths in this repo.
- **Status updated `Proposed` → `Accepted`.** The unification described in the Decision section shipped via `mdr_auth` and `api_key_auth` components; the Cognito flow alluded to in *Consequences* was implemented via #882/#883/#884. Added a pointer to [`self-serve-tenant-auth.md`](../tree/main/docs/design/cross-cutting/self-serve-tenant-auth.md) for the implemented architecture.

### `docs/overview/mdr-overview.md`
- The *Architecture → Authentication* bullet said "currently a small set of hardcoded demo users; self-serve Cognito is in design." Updated to describe the three implemented principal types (service API key / Cognito JWT / legacy HS256) with a pointer to the self-serve auth design doc.
- Replaced the *Learn More* pointer to the self-serve registration proposal (still in your untracked working tree, pending review) with a pointer to the implemented design doc.

cspell + relative-link audit: both clean.

### Audit findings that didn't make this PR (good follow-ups)

The audit also flagged content gaps that are real but bigger than mechanical fixes:

- **`docs/overview/services-overview.md`** (684 lines) — has zero mentions of Cognito, tenant routing, workspace selection, or self-serve. The big high-level architecture doc is missing a whole layer of recent work. Could be a small new section under "Core Data Services" or a top-level "Control Plane" section.
- **`docs/design/components/mdr.md`** (339 lines) — doesn't mention tenant routing, the `/tenants/*` endpoint family, or the schema-per-tenant model. Per-service design doc should describe these.

Both deserve their own PRs with content judgment.

## Test plan
- [x] cspell passes
- [x] Relative-link audit on the two changed files: zero broken
- [ ] Spot-check the rendered ADR + overview after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)