### PR TITLE
Issue #884: Don't auto-forward single-workspace users on explicit /workspaces nav

### DIFF
--- a/frontends/mdr-frontend/src/pages/AuthCallback.tsx
+++ b/frontends/mdr-frontend/src/pages/AuthCallback.tsx
@@ -34,12 +34,21 @@ const AuthCallback: React.FC = () => {
         completeLogin(user);
         trackLogin("cognito");
         // First-login default is /workspaces (lets the user pick which group
-        // to enter, or auto-redirects if they have exactly one). A stored
+        // to enter, or auto-forwards if they have exactly one). A stored
         // returnUrl from a deep-link wins so /invite/accept?token=… etc. still
         // lands where the user clicked.
+        //
+        // The `autoForwardIfSingle` state flag is only set on this implicit
+        // post-auth landing; clicking "Workspaces" in the nav later does not
+        // set it, so a single-workspace user can still reach the picker UI
+        // (to invite teammates) without being kicked to /explore.
         const stored = authService.getReturnUrl();
         const target = stored === "/" ? "/workspaces" : stored;
-        navigate(target, { replace: true });
+        const isWorkspaces = target === "/workspaces";
+        navigate(target, {
+          replace: true,
+          state: isWorkspaces ? { autoForwardIfSingle: true } : undefined,
+        });
       } catch (err) {
         trackLoginFailed("cognito");
         setError(err instanceof Error ? err.message : "Authentication failed");

--- a/frontends/mdr-frontend/src/pages/Home.tsx
+++ b/frontends/mdr-frontend/src/pages/Home.tsx
@@ -11,11 +11,17 @@ const Home: React.FC = () => {
 
   React.useEffect(() => {
     // Until we have a real home page, send a logged-in user landing on /
-    // to the workspace picker. The Workspaces page itself auto-forwards to
-    // /explore when the user has exactly one workspace, so this is mostly
-    // a brief loading screen for single-group users (the common case).
+    // to the workspace picker. Like AuthCallback, this is an implicit
+    // landing (user just typed the bare root URL), so pass the
+    // `autoForwardIfSingle` flag — a single-workspace user gets forwarded
+    // straight to /explore instead of seeing a one-card picker. Explicit
+    // navigation to /workspaces from the nav does NOT pass the flag and
+    // will stay on the page.
     if (window.location.pathname === "/") {
-      navigate("/workspaces", { replace: true });
+      navigate("/workspaces", {
+        replace: true,
+        state: { autoForwardIfSingle: true },
+      });
     }
   }, [navigate]);
 

--- a/frontends/mdr-frontend/src/pages/Workspaces.tsx
+++ b/frontends/mdr-frontend/src/pages/Workspaces.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -32,6 +32,15 @@ const AUTO_SELECT_REDIRECT = "/explore";
 
 const Workspaces: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  // Only auto-forward on implicit landings (AuthCallback + Home). Explicit
+  // navigation to /workspaces from the header nav or "Switch workspace"
+  // dropdown leaves this undefined, so a single-workspace user stays on the
+  // picker and can reach the Invite button. Read once at mount so a later
+  // history.replaceState doesn't change behavior mid-render.
+  const autoForwardIfSingle =
+    (location.state as { autoForwardIfSingle?: boolean } | null)
+      ?.autoForwardIfSingle === true;
 
   const [workspaces, setWorkspaces] = useState<WorkspaceItem[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -45,10 +54,11 @@ const Workspaces: React.FC = () => {
   const [inviteError, setInviteError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
-  // Load the list once. If the user has exactly one workspace, auto-select
-  // and forward to the app — this is the common case for a fresh registrant
-  // (post-confirmation lambda just provisioned their personal tenant) and
-  // we don't want to make them click a button to pick the only option.
+  // Load the list. On the implicit-landing path (autoForwardIfSingle), a
+  // single-workspace user is forwarded straight to /explore — the common
+  // case for a fresh registrant whose post-confirmation lambda just
+  // provisioned their one tenant. On explicit navigation we always show
+  // the picker so the user can reach the Invite button.
   useEffect(() => {
     let cancelled = false;
 
@@ -59,7 +69,7 @@ const Workspaces: React.FC = () => {
 
         setWorkspaces(items);
 
-        if (items.length === 1) {
+        if (autoForwardIfSingle && items.length === 1) {
           setSelecting(items[0].group);
           try {
             await tenantsService.select(items[0].group);
@@ -90,7 +100,7 @@ const Workspaces: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [navigate]);
+  }, [autoForwardIfSingle, navigate]);
 
   const handleSelect = async (group: string) => {
     setSelecting(group);


### PR DESCRIPTION
## Summary

UX fix surfaced during walkthrough prep for the 2026-05-27 demo: a user with exactly one workspace had no way to reach the `/workspaces` UI — every entry point auto-forwarded them to `/explore`, so they couldn't generate an invite link or see their workspace card.

The auto-forward in `Workspaces.tsx` was intended for fresh registrants who just confirmed their email (post-confirmation Lambda just provisioned their one tenant). That UX is still right on the *implicit* landing path. But the effect fires on every mount, so explicit clicks on "Workspaces" in the header or "Switch workspace" in the user dropdown also triggered it.

## Fix

Gate the auto-forward on a `location.state.autoForwardIfSingle` flag:

- `AuthCallback` sets the flag when navigating to `/workspaces` after sign-in (preserves the existing fresh-registrant UX)
- `Home` sets the flag when redirecting `/` → `/workspaces` (preserves the bare-root-URL UX)
- Explicit nav from the header, the user dropdown, or a direct URL-bar entry leaves the state undefined → picker shown
- `Workspaces.tsx` reads the flag from `location.state` and only auto-selects when it's `true`

No behavior change for multi-workspace users (auto-forward was always gated on `items.length === 1`).

## Behavior matrix

| Entry point | Before | After |
|---|---|---|
| Cognito sign-in → /workspaces | Auto-forward | Auto-forward (unchanged, flag set) |
| Bare `/` URL → /workspaces | Auto-forward | Auto-forward (unchanged, flag set) |
| Header nav "Workspaces" | Auto-forward 🐛 | **Picker shown** ✅ |
| User dropdown "Switch workspace" | Auto-forward 🐛 | **Picker shown** ✅ |
| Direct URL-bar `/workspaces` | Auto-forward 🐛 | **Picker shown** ✅ |

## Verification

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npx vite build` clean (499 modules transformed)
- [ ] Manual: register a fresh test user → confirm auto-forward to `/explore` still works
- [ ] Manual: as the same user, click "Workspaces" in the header → confirm picker now stays
- [ ] Manual: click "Open" on a workspace → confirm normal nav to `/explore` works

Deploys to dev automatically on merge via `lif_mdr_frontend.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)