### PR TITLE
Issue #883: Run `flyway repair` before `flyway migrate` in Lambda entrypoint

### DIFF
--- a/sam/mdr-database/flyway/flyway-files/flyway/lambda-entrypoint.sh
+++ b/sam/mdr-database/flyway/flyway-files/flyway/lambda-entrypoint.sh
@@ -38,6 +38,12 @@ then
     flyway clean -X || error "failed to successfully execute 'flyway clean' command"
 fi
 flyway info -X || error "flyway info before migrate command"
+# Repair before migrate: aligns schema_history checksums + descriptions
+# with the current migration files, and clears records for failed migrations
+# so they can be retried. Repair does NOT touch user data — only the Flyway
+# bookkeeping table. Idempotent + a no-op when checksums already match, so
+# it's safe to leave in the steady-state path.
+flyway repair -X || error "failed to successfully execute 'flyway repair' command"
 flyway migrate -X || error "failed to successfully execute 'flyway migrate' command"
 flyway info -X || error "flyway info after migrate command"
 respond $REQUEST_ID


### PR DESCRIPTION
## Summary

Add `flyway repair` to the Flyway Lambda's entrypoint immediately before `flyway migrate`. Repair is idempotent — it aligns the `flyway_schema_history` checksum/description columns with the on-disk migration files, and clears records for failed migrations so they can be retried. It does NOT touch user data; only the Flyway bookkeeping table.

## Why now

Discovered 2026-05-26 during a 6-week-overdue dev redeploy: `V1.1__metadata_repository_init.sql` had been edited multiple times since the dev DB was last reset, and the resulting checksum mismatch blocked V1.2+ from applying.

**Before this PR**, the recovery path was the destructive `reset-mdr-database.sh --apply` (Flyway `clean` + `migrate`, dropping every row in `public`). Workshop testers had accumulated 6 weeks of work in `public`; a reset would have erased it.

**After this PR**, repair realigns the V1.1 checksum to match the current file and migrate proceeds against the existing data. No reset required; tester data preserved.

## Operational benefits

| Scenario | Without repair | With repair |
|---|---|---|
| V1.1 edited in place (the documented convention, see CLAUDE.md "MDR Schema Migrations (V1.2+)") | Migrate fails with `FlywayValidateException: Migration checksum mismatch`. Recovery = full database reset. | Migrate silently realigns checksum and proceeds. |
| Higher-version migration partially fails | Failed entry sits in `flyway_schema_history`; retry blocked until manual cleanup. | Failed entry removed before next migrate; retry succeeds. |
| No checksum drift, no failures | Repair is a no-op (~1s) | Same |

## Tradeoff: silent realignment vs. loud detection

Auto-running repair means an accidental or malicious change to an applied migration would be silently absorbed instead of raising an exception. We accept that tradeoff because:

1. Edits to applied V1.1 are an explicit convention in this repo (per CLAUDE.md), so the "loud" behavior was already a false alarm.
2. Protective signal lives elsewhere — code review on the migration file change itself, CI, plus the underlying Flyway exception is still recoverable if `repair` is ever removed.
3. The reset script is still available for genuine "start from scratch" needs.

## What this enables

This PR is a prerequisite for #940 (the V1.3 / V1.4 ordering bug fix). Without repair-before-migrate, the V1.3 patch would leave a failed-migration record stuck in `flyway_schema_history` after each redeploy attempt.

## Test plan

- [x] Deployed against `dev` 2026-05-26; observed `Repairing Schema History table for version 1.1` followed by successful migrate of V1.2 — proves the recovery path works
- [ ] Apply on `demo` as part of the 2026-05-27 demo promotion (demo has the same V1.1 checksum drift)
- [ ] No-op behavior verification: run a second migrate immediately after the first; should see `No failed migration detected` and proceed to migrate (a no-op)

## Demo blocker?

Yes — this is part of the chain that gets `tenant_lif_team` populated for the 2026-05-27 demo. The repair step was required to clear the V1.1 checksum mismatch before V1.2-V1.4 could apply on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
