### PR TITLE
Issue #883: Fold V1.4's clone_lif_schema fix into V1.3 (correct migration ordering)

### DIFF
--- a/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.3__tenant_lif_team_schema.sql
+++ b/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.3__tenant_lif_team_schema.sql
@@ -13,6 +13,117 @@
 --
 -- Idempotent per the CLAUDE.md "MDR Schema Migrations (V1.2+)" convention:
 -- safe to re-run after local `docker compose down -v` cycles.
+--
+-- 2026-05-26 patch: V1.4's corrected clone_lif_schema function definition
+-- is folded in here as a prefix because Flyway runs migrations in version
+-- order (V1.3 then V1.4). V1.2's original function had four bugs
+-- (GENERATED ALWAYS / FK ordering / identity sequences / setval quoting)
+-- that all surfaced on the first invocation against a fresh DB. Without
+-- this prefix V1.3 raised "cannot insert a non-DEFAULT value into column
+-- 'Id'" and rolled back, leaving tenant_lif_team uncreated. V1.4 still
+-- runs after this migration and is now a no-op (CREATE OR REPLACE with
+-- identical content). Long-term cleanup: collapse V1.2, V1.3, V1.4 into
+-- a single corrected migration once we're confident the deployed envs
+-- have caught up; tracked in a follow-up.
+
+CREATE OR REPLACE FUNCTION public.clone_lif_schema(
+    target_schema text,
+    include_data boolean DEFAULT true
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    tbl_name text;
+    seq_name text;
+    seq_value bigint;
+    fk_def text;
+    fk_rec record;
+BEGIN
+    IF target_schema !~ '^tenant_[a-z][a-z0-9_]*$' THEN
+        RAISE EXCEPTION 'clone_lif_schema: target_schema must match tenant_[a-z][a-z0-9_]* (got %)', target_schema;
+    END IF;
+    IF length(target_schema) > 63 THEN
+        RAISE EXCEPTION 'clone_lif_schema: target_schema exceeds PG''s 63-char identifier limit (%)', target_schema;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = target_schema) THEN
+        RAISE EXCEPTION 'clone_lif_schema: target schema % already exists', target_schema
+            USING ERRCODE = 'duplicate_schema';
+    END IF;
+
+    EXECUTE format('CREATE SCHEMA %I', target_schema);
+
+    -- Tables: copy structure (columns, defaults, PKs, indexes, NOT NULL,
+    -- CHECK constraints, identity columns, storage). FKs come after data
+    -- so the per-row order of inserts doesn't matter.
+    FOR tbl_name IN
+        SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename
+    LOOP
+        EXECUTE format(
+            'CREATE TABLE %I.%I (LIKE public.%I INCLUDING ALL)',
+            target_schema, tbl_name, tbl_name
+        );
+    END LOOP;
+
+    -- Data: copy every row before FKs exist. OVERRIDING SYSTEM VALUE is
+    -- required for the GENERATED ALWAYS "Id" columns; we deliberately
+    -- preserve source Ids so cross-table refs stay intact in the clone.
+    IF include_data THEN
+        FOR tbl_name IN
+            SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename
+        LOOP
+            EXECUTE format(
+                'INSERT INTO %I.%I OVERRIDING SYSTEM VALUE SELECT * FROM public.%I',
+                target_schema, tbl_name, tbl_name
+            );
+        END LOOP;
+    END IF;
+
+    -- FKs: lift each constraint from public and reattach to the equivalent
+    -- target table. ADD CONSTRAINT FOREIGN KEY validates every existing row
+    -- in one shot, so if source data violates referential integrity the
+    -- clone still fails loudly here rather than silently producing a tenant
+    -- whose data doesn't match its own constraints.
+    FOR fk_rec IN
+        SELECT
+            src.relname AS source_table,
+            con.conname AS constraint_name,
+            pg_get_constraintdef(con.oid) AS definition
+        FROM pg_constraint con
+        JOIN pg_class src ON con.conrelid = src.oid
+        JOIN pg_namespace ns ON src.relnamespace = ns.oid
+        WHERE ns.nspname = 'public' AND con.contype = 'f'
+    LOOP
+        fk_def := regexp_replace(
+            fk_rec.definition,
+            'REFERENCES (public\.)?',
+            format('REFERENCES %I.', target_schema)
+        );
+        EXECUTE format(
+            'ALTER TABLE %I.%I ADD CONSTRAINT %I %s',
+            target_schema, fk_rec.source_table, fk_rec.constraint_name, fk_def
+        );
+    END LOOP;
+
+    -- Sequences: sync last_value so the next nextval() in the tenant schema
+    -- starts after the copied data, not from 1. Only relevant when data
+    -- was copied; otherwise the per-tenant sequences are at their defaults.
+    IF include_data THEN
+        FOR seq_name IN
+            SELECT sequencename FROM pg_sequences WHERE schemaname = target_schema
+        LOOP
+            EXECUTE format('SELECT last_value FROM public.%I', seq_name) INTO seq_value;
+            -- setval() takes the regclass name as a text literal; PG folds
+            -- unquoted identifiers to lowercase, so the LIF mixed-case
+            -- sequences (e.g. Entities_Id_seq) need the %I.%I double-quoting.
+            EXECUTE format('SELECT setval(%L, %s, true)', format('%I.%I', target_schema, seq_name), seq_value);
+        END LOOP;
+    END IF;
+END;
+$$;
 
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary

V1.3 currently calls `clone_lif_schema('tenant_lif_team')` against the buggy V1.2 function definition, so it fails on every fresh DB before Flyway can apply V1.4's fix. Fold V1.4's corrected function definition into V1.3 as a prefix so the working version of the function is in the DB *before* the clone is attempted.

## The bug

Flyway applies migrations in numeric version order: V1.2 → V1.3 → V1.4.

```
V1.2  CREATE OR REPLACE FUNCTION public.clone_lif_schema  -- four bugs (PR #883)
V1.3  PERFORM public.clone_lif_schema('tenant_lif_team')  -- FAILS
V1.4  CREATE OR REPLACE FUNCTION public.clone_lif_schema  -- the fix (PR #912, 363fa58)
```

V1.4 was authored as a follow-up to fix four bugs that shipped in the original V1.2 function. But Flyway can't reach V1.4 without V1.3 succeeding first. On any fresh deployed env that's never had `tenant_lif_team`, V1.3 raises:

```
ERROR: cannot insert a non-DEFAULT value into column "Id"
Detail: Column "Id" is an identity column defined as GENERATED ALWAYS.
```

## Why local docker-compose has been hiding this

`restore.sh` loads `backup.sql` before running migrations, and the backup already contains `tenant_lif_team`. V1.3's `IF NOT EXISTS` guard makes it a no-op there, so V1.4's fix appears to land cleanly — except the function was never actually exercised against real data in that flow. On a deployed env where `tenant_lif_team` doesn't exist yet, V1.3 has to actually call the function, and that's where the four bugs surface.

## The fix

Prepend V1.4's full `CREATE OR REPLACE FUNCTION public.clone_lif_schema(...)` body to V1.3. V1.4 still runs after V1.3 but is now an idempotent no-op (same content).

```diff
+ -- 2026-05-26 patch: V1.4's corrected clone_lif_schema function definition
+ -- is folded in here as a prefix because Flyway runs migrations in version
+ -- order (V1.3 then V1.4). V1.2's original function had four bugs ...
+
+ CREATE OR REPLACE FUNCTION public.clone_lif_schema(target_schema text, include_data boolean DEFAULT true) ...
+
  DO $$
  BEGIN
      IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'tenant_lif_team') THEN
          PERFORM public.clone_lif_schema('tenant_lif_team', TRUE);
      END IF;
  END
  $$;
```

## Compatibility

| Environment | Behavior |
|---|---|
| Fresh deployed env (no prior V1.2-V1.4 history) | V1.2 (buggy) → V1.3 (re-defines function corrected, then clones) → V1.4 (CREATE OR REPLACE same content, no-op). Works. |
| Deployed env where the *old* V1.3 already ran successfully (none known) | New V1.3 file checksum differs from the recorded one. `flyway migrate` raises `FlywayValidateException`. Handled by the companion `flyway repair` PR #939. |
| Local docker-compose (uses `psql`, not Flyway) | The new V1.3 still has the `IF NOT EXISTS` guard, so the clone is skipped if `tenant_lif_team` already exists from `backup.sql`. The function re-definition runs (idempotent). Works. |

## Companion PR

[#939](https://github.com/LIF-Initiative/lif-core/pull/939) — adds `flyway repair` before `flyway migrate` in the Lambda entrypoint. **Recommended merge order: #939 first**, then this. Without repair-before-migrate, any env that has the old V1.3 in `flyway_schema_history` will block on the checksum change introduced here.

## Demo blocker

Yes. This PR is what unblocked `tenant_lif_team` from being populated on dev today, and the same path is required for tomorrow's 2026-05-27 demo on `demo`.

## Long-term cleanup (out of scope here)

Collapse V1.2, V1.3, V1.4 into a single corrected migration once all deployed envs have caught up. Tracked as a follow-up.

## Test plan

- [x] Deployed against `dev` 2026-05-26; `tenant_lif_team` now has 20 data models cloned from `public`. `/datamodels/` returns HTTP 200.
- [x] `/tenants/provision` now succeeds for new evaluator registrations (function exists + works).
- [ ] Apply on `demo` for the 2026-05-27 demo promotion.
- [ ] Manual: a fresh test user can register and operate against their personal cloned tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)