### PR TITLE
Issue #936: Show currently-selected workspace in the header

### DIFF
--- a/frontends/mdr-frontend/src/components/Header/Header.tsx
+++ b/frontends/mdr-frontend/src/components/Header/Header.tsx
@@ -85,7 +85,14 @@ const Header: React.FC = () => {
 
         {/* Current-workspace indicator + user menu */}
         <Flex align="center" gap="3">
-          {currentWorkspace && (
+          {/* Guard `tenant_schema` defensively. The TypeScript type marks
+              it required, but `currentWorkspace` originates from
+              localStorage — runtime-untyped — so a corrupted or partially-
+              written value could otherwise render the badge with the
+              friendly-name line populated and the schema line blank.
+              Hiding the entire badge in that case is the safer rendering
+              (per Adam Hungerford review note 2026-05-27). */}
+          {currentWorkspace && currentWorkspace.tenant_schema && (
             <Badge
               color="iris"
               variant="soft"

--- a/frontends/mdr-frontend/src/components/Header/Header.tsx
+++ b/frontends/mdr-frontend/src/components/Header/Header.tsx
@@ -1,9 +1,13 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { NavLink, useNavigate } from "react-router-dom";
-import { Button, DropdownMenu, Flex, Text } from "@radix-ui/themes";
-import { PersonIcon, ExitIcon, EnterIcon } from "@radix-ui/react-icons";
+import { Badge, Button, DropdownMenu, Flex, Text } from "@radix-ui/themes";
+import { PersonIcon, ExitIcon, EnterIcon, LayersIcon } from "@radix-ui/react-icons";
 import { useAuth } from "../../context/AuthContext";
 import authService from "../../services/authService";
+import tenantsService, {
+  WORKSPACE_CHANGE_EVENT,
+  type WorkspaceItem,
+} from "../../services/tenantsService";
 import "./Header.css";
 
 const Header: React.FC = () => {
@@ -23,7 +27,28 @@ const Header: React.FC = () => {
     };
   }
 
+  // Subscribe to the currently-selected workspace (mirrored in localStorage by
+  // tenantsService.select). Re-read on the custom event we dispatch when the
+  // selection changes, and on the cross-tab `storage` event so multi-tab users
+  // see the same indicator everywhere.
+  const [currentWorkspace, setCurrentWorkspace] = useState<WorkspaceItem | null>(
+    () => tenantsService.getCurrentWorkspace(),
+  );
+  useEffect(() => {
+    const refresh = () => setCurrentWorkspace(tenantsService.getCurrentWorkspace());
+    window.addEventListener(WORKSPACE_CHANGE_EVENT, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(WORKSPACE_CHANGE_EVENT, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+
   const handleLogout = async () => {
+    // Clear the mirrored workspace before the auth redirect; otherwise the
+    // next user on the same browser would briefly see the previous user's
+    // workspace badge before their own selection lands.
+    tenantsService.clearCurrentWorkspace();
     await logout();
     // For Cognito, logout() redirects away. For legacy, navigate to login.
     if (!auth?.isCognito) {
@@ -58,8 +83,24 @@ const Header: React.FC = () => {
           </NavLink>
         </nav>
 
-        {/* User Menu */}
+        {/* Current-workspace indicator + user menu */}
         <Flex align="center" gap="3">
+          {currentWorkspace && (
+            <Badge
+              color="iris"
+              variant="soft"
+              size="2"
+              title={`Schema: ${currentWorkspace.tenant_schema}`}
+            >
+              <LayersIcon />
+              <Flex direction="column" align="start" gap="0">
+                <Text size="2" weight="medium">{currentWorkspace.group}</Text>
+                <Text size="1" color="gray" style={{ fontFamily: "monospace" }}>
+                  {currentWorkspace.tenant_schema}
+                </Text>
+              </Flex>
+            </Badge>
+          )}
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               <Button variant="ghost" size="2">

--- a/frontends/mdr-frontend/src/services/tenantsService.ts
+++ b/frontends/mdr-frontend/src/services/tenantsService.ts
@@ -29,6 +29,44 @@ export interface AcceptInviteResponse {
   inviter_sub: string;
 }
 
+// ---- Currently-selected workspace (client-side mirror) ----
+//
+// The backend writes the actual selection into the HttpOnly `lif_workspace`
+// cookie, which the frontend can't read. We mirror the selection into
+// localStorage so the header can show "you are operating against <X>" without
+// a round-trip to the backend.
+//
+// Trade-off accepted for v1: localStorage is per-browser. A user on a fresh
+// browser whose cookie is still valid (server-side) will see the indicator
+// as empty until their next /tenants/select call. Issue #936 tracks the
+// proper backend-driven `GET /tenants/current` follow-up.
+
+const WORKSPACE_STORAGE_KEY = "lif:currentWorkspace";
+const WORKSPACE_CHANGE_EVENT = "lif:workspace-changed";
+
+function readCurrentWorkspace(): WorkspaceItem | null {
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as WorkspaceItem) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCurrentWorkspace(workspace: WorkspaceItem | null): void {
+  try {
+    if (workspace) {
+      window.localStorage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify(workspace));
+    } else {
+      window.localStorage.removeItem(WORKSPACE_STORAGE_KEY);
+    }
+    window.dispatchEvent(new CustomEvent(WORKSPACE_CHANGE_EVENT));
+  } catch {
+    // localStorage can throw in private-mode Safari etc. Indicator is
+    // best-effort; failing silently is preferable to blocking the select.
+  }
+}
+
 // ---- Service ----
 
 /**
@@ -44,6 +82,8 @@ class TenantsService {
 
   async select(group: string): Promise<SelectWorkspaceResponse> {
     const response = await api.post<SelectWorkspaceResponse>("/tenants/select", { group });
+    // Mirror into localStorage so the header indicator reflects the change.
+    writeCurrentWorkspace(response.data);
     return response.data;
   }
 
@@ -56,6 +96,15 @@ class TenantsService {
     const response = await api.post<AcceptInviteResponse>("/tenants/invite/accept", { token });
     return response.data;
   }
+
+  getCurrentWorkspace(): WorkspaceItem | null {
+    return readCurrentWorkspace();
+  }
+
+  clearCurrentWorkspace(): void {
+    writeCurrentWorkspace(null);
+  }
 }
 
+export { WORKSPACE_CHANGE_EVENT };
 export default new TenantsService();


### PR DESCRIPTION
Closes #942 (PM ask) — also resolves #936 (engineering follow-up).

## Summary

Adds a workspace indicator badge to the right side of the header, next to the user dropdown. Shows the currently-selected workspace's `group` (prominent) and `tenant_schema` (smaller monospace). Visible after the user picks a workspace (or after auto-forward on single-workspace users).

Closes #936 via the "Option A" path (localStorage mirror); the proper "Option B" (backend `GET /tenants/current`) remains a follow-up.

## Why now

Surfaced 2026-05-26 in PM + @cbeach47 review of the demo flow: users had no visual cue which tenant they were operating against. Asked for during the 2026-05-27 client demo prep.

## Implementation

| File | Change |
|---|---|
| `services/tenantsService.ts` | Add `getCurrentWorkspace()` / `clearCurrentWorkspace()`. `select()` mirrors the response into `localStorage["lif:currentWorkspace"]` and dispatches a `lif:workspace-changed` window event. |
| `components/Header/Header.tsx` | Subscribe to that event + cross-tab `storage` events; render a Radix `<Badge>` with `group` + `tenant_schema`. Logout clears the mirror. |

### Trade-off (per issue #936)

LocalStorage is per-browser. A user on a fresh browser whose `lif_workspace` cookie is still valid server-side will see the badge as empty until they next visit `/workspaces` and select. The cleaner long-term fix is a `GET /tenants/current` endpoint (a `WorkspaceItem`-shaped echo of the cookie's resolved selection), which the SPA would query once on app boot and cache. That backend work is noted in #936; this PR ships the cheaper path because the indicator was demo-blocking.

## Display

- `group` prominent (medium weight) — e.g. `lif-team`
- `tenant_schema` smaller monospace below — e.g. `tenant_lif_team`
- Wrapped in a `LayersIcon`+`Badge` for a workspace/layer cue
- Tooltip on hover shows the schema name (for the case where the badge wraps)

This keeps the actual schema visible per the PM ask ("keep the display of actual schema under workspace name"). The companion ask ("default the visible name to the user's email for personal tenants instead of `eval-<sub>`") is the *friendly name* follow-up, filed separately — keeping that out of this PR so the indicator can land first.

## Verification

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npx vite build` clean (499 modules)
- [ ] Manual: select a workspace → badge appears with the right values
- [ ] Manual: log out → badge clears for the next sign-in
- [ ] Manual: open two tabs of the SPA in the same browser, select a workspace in one → both see the badge update (cross-tab `storage` event)

Auto-deploys to dev on merge via `lif_mdr_frontend.yml`. Demo is 2026-05-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
