### PR TITLE
Customize Cognito verification email subject + body

### DIFF
--- a/cloudformation/cognito-selfserve.yml
+++ b/cloudformation/cognito-selfserve.yml
@@ -35,6 +35,25 @@ Resources:
         - email
       UsernameAttributes:
         - email
+      # Customize the verification email so recipients see a branded subject
+      # they recognize as "the thing they just signed up for" rather than
+      # Cognito's generic boilerplate, which Gmail/Outlook spam heuristics
+      # frequently flag. Sender is still Cognito's default
+      # (no-reply@verificationemail.com); migrating to SES requires AWS
+      # production-access approval and is deferred.
+      VerificationMessageTemplate:
+        DefaultEmailOption: CONFIRM_WITH_CODE
+        EmailSubject: !Sub "LIF Metadata Repository (${EnvironmentName}) — confirm your email"
+        EmailMessage: |
+          Welcome to the LIF Metadata Repository self-serve evaluator program.
+
+          Your 6-digit confirmation code is {####}.
+
+          Enter this code on the registration page to complete sign-up. If
+          you didn't request this account, no action is needed and the
+          account will not be created.
+
+          (If you don't see this in your inbox, please check Spam / Junk.)
       Schema:
         - Name: email
           AttributeDataType: String


### PR DESCRIPTION
Closes #941 (PM ask) — tactical mitigation only; sender-address change to @unicon.net requires SES production access (deferred, in follow-up).

## Summary

Adds a `VerificationMessageTemplate` to the self-serve Cognito user pool with a branded subject and a friendly body. Tactical anti-spam mitigation surfaced during the 2026-05-26 PM + @cbeach47 demo-prep call.

## Why

Recipients of the registration code were reporting it landed in Gmail / Outlook spam. The default Cognito email is generic enough that anti-spam heuristics catch it; the body doesn't identify the product so even users digging through spam couldn't recognize it.

## Change

```yaml
VerificationMessageTemplate:
  DefaultEmailOption: CONFIRM_WITH_CODE
  EmailSubject: !Sub "LIF Metadata Repository (${EnvironmentName}) — confirm your email"
  EmailMessage: |
    Welcome to the LIF Metadata Repository self-serve evaluator program.

    Your 6-digit confirmation code is {####}.

    Enter this code on the registration page to complete sign-up. ...

    (If you don't see this in your inbox, please check Spam / Junk.)
```

## Not the proper fix

The message still goes through Cognito's default sender (`no-reply@verificationemail.com`), which is the actual cause of the spam classification. Migrating to `EmailSendingAccount: DEVELOPER` + SES with a domain-verified sender (DKIM/SPF/DMARC on a `unicon.net` subdomain) is the real fix. That's blocked on AWS granting SES production-access (SES is currently in sandbox and AWS approval typically takes hours-to-days). Filed as a follow-up.

## Deploy status

Already applied to **dev** on 2026-05-26 via the changeset path (verified via `aws cognito-idp describe-user-pool`). This PR is the repo catch-up so the template in `main` matches what's deployed. Demo on 2026-05-27 will benefit immediately.

For **demo** promotion (per `884-demo-promotion-cheatsheet.md`), this lands when `demo-lif-mdr-cognito` is next deployed.

## Test plan

- [x] Deploy on dev (done): subject + body confirmed via `describe-user-pool`
- [ ] Manual: register a fresh email → check inbox + spam for the customized subject
- [ ] Apply on demo for 2026-05-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
