### PR TITLE
Issue #943: Friendly display_name on workspaces (initial stab)

### DIFF
--- a/bases/lif/mdr_restapi/tenant_endpoints.py
+++ b/bases/lif/mdr_restapi/tenant_endpoints.py
@@ -87,6 +87,10 @@ class SelectWorkspaceRequest(BaseModel):
 class SelectWorkspaceResponse(BaseModel):
     group: str
     tenant_schema: str
+    # display_name mirrors the friendly label from /tenants/mine so the
+    # frontend can update its workspace indicator immediately on select
+    # without a follow-up listing round-trip (issue #943).
+    display_name: str
 
 
 class CreateInviteRequest(BaseModel):
@@ -231,8 +235,12 @@ async def list_my_workspaces(
     receive an empty list.
     """
     cognito_groups: list[str] = getattr(request.state, "cognito_groups", [])
+    cognito_sub: str | None = getattr(request.state, "cognito_sub", None)
+    principal: str | None = getattr(request.state, "principal", None)
     workspaces = list_workspaces_for_groups(cognito_groups)
-    return ListMyWorkspacesResponse(workspaces=[to_workspace_item(w) for w in workspaces])
+    return ListMyWorkspacesResponse(
+        workspaces=[to_workspace_item(w, cognito_sub=cognito_sub, principal=principal) for w in workspaces]
+    )
 
 
 @router.post(
@@ -285,7 +293,10 @@ async def select_workspace(
         path="/",
     )
     logger.info("User %r selected workspace %r → %s", request.state.principal, workspace.group, workspace.tenant_schema)
-    return SelectWorkspaceResponse(group=workspace.group, tenant_schema=workspace.tenant_schema)
+    cognito_sub: str | None = getattr(request.state, "cognito_sub", None)
+    principal: str | None = getattr(request.state, "principal", None)
+    item = to_workspace_item(workspace, cognito_sub=cognito_sub, principal=principal)
+    return SelectWorkspaceResponse(group=item.group, tenant_schema=item.tenant_schema, display_name=item.display_name)
 
 
 @router.post(

--- a/components/lif/mdr_services/workspace_service.py
+++ b/components/lif/mdr_services/workspace_service.py
@@ -31,18 +31,58 @@ class WorkspaceItem(BaseModel):
     """API response shape for a workspace.
 
     Separate from the internal ``Workspace`` dataclass so the wire
-    contract can evolve independently of in-process types — e.g., we
-    might later add ``display_name`` or ``schema_status`` to the API
-    without changing the service-layer return shape.
+    contract can evolve independently of in-process types.
+
+    ``display_name`` is the human-friendly label the SPA shows in the
+    workspace picker + header indicator (issue #943). For a user's own
+    auto-created personal tenant (``eval-<their-cognito-sub>``), this is
+    their email — meaningful to the user and consistent with how the
+    rest of the LIF stack identifies them. For shared / invited groups
+    (``lif-team`` and future named teams), it's the group name itself.
+    The technical ``tenant_schema`` stays on every record so the picker
+    can still surface it as secondary text.
     """
 
     group: str
     tenant_schema: str
+    display_name: str
 
 
-def to_workspace_item(workspace: Workspace) -> WorkspaceItem:
-    """Project a service-layer ``Workspace`` into its API response shape."""
-    return WorkspaceItem(group=workspace.group, tenant_schema=workspace.tenant_schema)
+def compute_display_name(group: str, cognito_sub: str | None, principal: str | None) -> str:
+    """Resolve a friendly display name for a Cognito group (issue #943).
+
+    For the user's own personal tenant (``eval-<their-sub>``), where we
+    can confidently match the JWT's ``sub`` against the group's suffix,
+    use the user's email — which the auth middleware stores as
+    ``request.state.principal`` for Cognito users with a verified
+    email claim. The ``@`` is intentional; PM call on 2026-05-26
+    explicitly confirmed it's fine in the UI.
+
+    For any group that isn't the caller's own ``eval-<sub>``, keep the
+    group name as-is. That covers shared groups (``lif-team``, future
+    named teams), invited memberships, and the edge case where
+    ``principal`` is a raw sub (legacy HS256 path, no email claim).
+    """
+    if cognito_sub is not None and principal is not None and "@" in principal and group == f"eval-{cognito_sub}":
+        return principal
+    return group
+
+
+def to_workspace_item(
+    workspace: Workspace, *, cognito_sub: str | None = None, principal: str | None = None
+) -> WorkspaceItem:
+    """Project a service-layer ``Workspace`` into its API response shape.
+
+    Computes ``display_name`` from the optional caller-identity hints.
+    Callers without identity context (tests that don't care about the
+    friendly label) get ``display_name = group``, matching pre-#943
+    behavior.
+    """
+    return WorkspaceItem(
+        group=workspace.group,
+        tenant_schema=workspace.tenant_schema,
+        display_name=compute_display_name(workspace.group, cognito_sub, principal),
+    )
 
 
 def list_workspaces_for_groups(cognito_groups: list[str] | None) -> list[Workspace]:

--- a/components/lif/mdr_services/workspace_service.py
+++ b/components/lif/mdr_services/workspace_service.py
@@ -48,7 +48,7 @@ class WorkspaceItem(BaseModel):
     display_name: str
 
 
-def compute_display_name(group: str, cognito_sub: str | None, principal: str | None) -> str:
+def compute_display_name(group: str, cognito_sub: str | None, principal: str | None, tenant_schema: str) -> str:
     """Resolve a friendly display name for a Cognito group (issue #943).
 
     For the user's own personal tenant (``eval-<their-sub>``), where we
@@ -58,14 +58,25 @@ def compute_display_name(group: str, cognito_sub: str | None, principal: str | N
     email claim. The ``@`` is intentional; PM call on 2026-05-26
     explicitly confirmed it's fine in the UI.
 
-    For any group that isn't the caller's own ``eval-<sub>``, keep the
-    group name as-is. That covers shared groups (``lif-team``, future
-    named teams), invited memberships, and the edge case where
-    ``principal`` is a raw sub (legacy HS256 path, no email claim).
+    For any group that isn't the caller's own ``eval-<sub>``, use the
+    group name. That covers shared groups (``lif-team``, future named
+    teams), invited memberships, and the edge case where ``principal``
+    is a raw sub (legacy HS256 path, no email claim).
+
+    ``tenant_schema`` is the ultimate fallback. The wire contract for
+    ``display_name`` is "never empty"; if both the personal and group
+    paths somehow produced an empty/whitespace-only string (group is
+    impossibly empty, principal is whitespace-only, etc.), the schema
+    name is preferable to a blank label in the SPA. Per Adam Hungerford
+    review of #947 — defense in depth on a server-side invariant the
+    frontend now relies on.
     """
     if cognito_sub is not None and principal is not None and "@" in principal and group == f"eval-{cognito_sub}":
-        return principal
-    return group
+        candidate = principal
+    else:
+        candidate = group
+    candidate = candidate.strip()
+    return candidate if candidate else tenant_schema
 
 
 def to_workspace_item(
@@ -75,13 +86,14 @@ def to_workspace_item(
 
     Computes ``display_name`` from the optional caller-identity hints.
     Callers without identity context (tests that don't care about the
-    friendly label) get ``display_name = group``, matching pre-#943
-    behavior.
+    friendly label) get ``display_name = group`` (or ``tenant_schema``
+    if the group somehow sanitizes to empty), matching pre-#943
+    behavior modulo the empty-string defense.
     """
     return WorkspaceItem(
         group=workspace.group,
         tenant_schema=workspace.tenant_schema,
-        display_name=compute_display_name(workspace.group, cognito_sub, principal),
+        display_name=compute_display_name(workspace.group, cognito_sub, principal, workspace.tenant_schema),
     )
 
 

--- a/frontends/mdr-frontend/src/pages/Workspaces.tsx
+++ b/frontends/mdr-frontend/src/pages/Workspaces.tsx
@@ -255,7 +255,10 @@ const Workspaces: React.FC = () => {
             <Card key={ws.group}>
               <Flex align="center" justify="between" gap="3">
                 <Box>
-                  <Heading size="4">{ws.group}</Heading>
+                  {/* display_name is the friendly label (email for personal
+                      tenants, group name for shared); fall back to group
+                      while the backend rolls out. Issue #943. */}
+                  <Heading size="4">{ws.display_name ?? ws.group}</Heading>
                   <Text size="1" color="gray">
                     Schema: {ws.tenant_schema}
                   </Text>

--- a/frontends/mdr-frontend/src/pages/Workspaces.tsx
+++ b/frontends/mdr-frontend/src/pages/Workspaces.tsx
@@ -256,9 +256,16 @@ const Workspaces: React.FC = () => {
               <Flex align="center" justify="between" gap="3">
                 <Box>
                   {/* display_name is the friendly label (email for personal
-                      tenants, group name for shared); fall back to group
-                      while the backend rolls out. Issue #943. */}
-                  <Heading size="4">{ws.display_name ?? ws.group}</Heading>
+                      tenants, group name for shared). Backend guarantees
+                      it's present and non-empty — `compute_display_name`
+                      falls through to `tenant_schema` rather than ever
+                      returning an empty string. Using `||` not `??` so a
+                      corrupted runtime value (manual localStorage edit,
+                      future code path that writes an empty string) still
+                      falls back to `group` rather than rendering a blank
+                      heading — defense in depth per Adam Hungerford
+                      review of #947. */}
+                  <Heading size="4">{ws.display_name || ws.group}</Heading>
                   <Text size="1" color="gray">
                     Schema: {ws.tenant_schema}
                   </Text>

--- a/frontends/mdr-frontend/src/services/tenantsService.ts
+++ b/frontends/mdr-frontend/src/services/tenantsService.ts
@@ -8,11 +8,15 @@ export interface WorkspaceItem {
   /**
    * Friendly human-readable label (issue #943). For a user's own auto-
    * created personal tenant this is their email; for shared groups
-   * (lif-team, etc.) it's the group name. Optional on the wire because
-   * the backend rollout may lag the frontend — callers should fall back
-   * to `group` when this is missing.
+   * (lif-team, etc.) it's the group name. The backend guarantees this
+   * field is always present and non-empty — `compute_display_name`
+   * falls through to `tenant_schema` rather than ever returning an
+   * empty string. Consumers that still want to be defensive about
+   * runtime corruption (e.g. localStorage cookie mirror) should use
+   * `display_name || group` rather than `display_name ?? group` so an
+   * empty-string edge case doesn't render as a blank label.
    */
-  display_name?: string;
+  display_name: string;
 }
 
 interface ListMyWorkspacesResponse {
@@ -22,7 +26,7 @@ interface ListMyWorkspacesResponse {
 export interface SelectWorkspaceResponse {
   group: string;
   tenant_schema: string;
-  display_name?: string;
+  display_name: string;
 }
 
 export interface CreateInviteResponse {

--- a/frontends/mdr-frontend/src/services/tenantsService.ts
+++ b/frontends/mdr-frontend/src/services/tenantsService.ts
@@ -5,6 +5,14 @@ import api from "./api";
 export interface WorkspaceItem {
   group: string;
   tenant_schema: string;
+  /**
+   * Friendly human-readable label (issue #943). For a user's own auto-
+   * created personal tenant this is their email; for shared groups
+   * (lif-team, etc.) it's the group name. Optional on the wire because
+   * the backend rollout may lag the frontend — callers should fall back
+   * to `group` when this is missing.
+   */
+  display_name?: string;
 }
 
 interface ListMyWorkspacesResponse {
@@ -14,6 +22,7 @@ interface ListMyWorkspacesResponse {
 export interface SelectWorkspaceResponse {
   group: string;
   tenant_schema: string;
+  display_name?: string;
 }
 
 export interface CreateInviteResponse {

--- a/test/bases/lif/mdr_restapi/test_tenant_endpoints.py
+++ b/test/bases/lif/mdr_restapi/test_tenant_endpoints.py
@@ -190,8 +190,29 @@ class TestListMyWorkspaces:
         assert resp.status_code == 200
         assert resp.json() == {
             "workspaces": [
-                {"group": "lif-team", "tenant_schema": "tenant_lif_team"},
-                {"group": "acme-univ", "tenant_schema": "tenant_acme_univ"},
+                {"group": "lif-team", "tenant_schema": "tenant_lif_team", "display_name": "lif-team"},
+                {"group": "acme-univ", "tenant_schema": "tenant_acme_univ", "display_name": "acme-univ"},
+            ]
+        }
+
+    async def test_personal_tenant_display_name_is_email(self, client, monkeypatch):
+        """For a user's own auto-created eval-<sub> tenant the friendly
+        display_name should be their email, not the cryptic eval-<sub>
+        group label. Shared groups in the same list keep their group
+        name. (Issue #943.)"""
+        _stub_cognito_principal(
+            monkeypatch, "user@example.com", ["lif-team", "eval-cognito-sub-test"], cognito_sub="cognito-sub-test"
+        )
+        resp = await client.get("/tenants/mine")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "workspaces": [
+                {"group": "lif-team", "tenant_schema": "tenant_lif_team", "display_name": "lif-team"},
+                {
+                    "group": "eval-cognito-sub-test",
+                    "tenant_schema": "tenant_eval_cognito_sub_test",
+                    "display_name": "user@example.com",
+                },
             ]
         }
 
@@ -225,7 +246,7 @@ class TestSelectWorkspace:
         _stub_cognito_principal(monkeypatch, "user@example.com", ["lif-team", "acme-univ"])
         resp = await client.post("/tenants/select", json={"group": "acme-univ"})
         assert resp.status_code == 200
-        assert resp.json() == {"group": "acme-univ", "tenant_schema": "tenant_acme_univ"}
+        assert resp.json() == {"group": "acme-univ", "tenant_schema": "tenant_acme_univ", "display_name": "acme-univ"}
         # The Set-Cookie header carries the lif_workspace cookie
         set_cookie = resp.headers.get("set-cookie", "")
         assert "lif_workspace=" in set_cookie

--- a/test/components/lif/mdr_services/test_workspace_service.py
+++ b/test/components/lif/mdr_services/test_workspace_service.py
@@ -1,6 +1,12 @@
 """Unit tests for workspace_service — pure helpers, no DB."""
 
-from lif.mdr_services.workspace_service import Workspace, find_workspace, list_workspaces_for_groups
+from lif.mdr_services.workspace_service import (
+    Workspace,
+    compute_display_name,
+    find_workspace,
+    list_workspaces_for_groups,
+    to_workspace_item,
+)
 
 
 class TestListWorkspacesForGroups:
@@ -45,3 +51,85 @@ class TestFindWorkspace:
         """Even if --- somehow ended up in cognito_groups, we shouldn't
         route a request to an empty tenant_ schema."""
         assert find_workspace(["---"], "---") is None
+
+
+class TestComputeDisplayName:
+    """Friendly display name resolution (issue #943).
+
+    For a user's own personal tenant the display name is their email
+    (verified via the eval-<sub> group / JWT sub match). For any other
+    group the display name is just the group name as today.
+    """
+
+    def test_personal_tenant_uses_email_when_match(self):
+        # Cognito's sub claim is `abc123`; the post-confirmation Lambda
+        # created `eval-abc123` for them. The user's email is on
+        # principal. Display name should be the email.
+        assert (
+            compute_display_name(group="eval-abc123", cognito_sub="abc123", principal="user@example.edu")
+            == "user@example.edu"
+        )
+
+    def test_shared_group_uses_group_name(self):
+        # User is in lif-team (a shared group). Even though we have the
+        # email on principal, the group name is the right friendly label
+        # for a shared workspace.
+        assert compute_display_name(group="lif-team", cognito_sub="abc123", principal="user@example.edu") == "lif-team"
+
+    def test_eval_group_for_different_sub_does_not_use_email(self):
+        # Defense-in-depth: if another user's eval-* group somehow ended
+        # up in the caller's group list (shouldn't happen — the post-
+        # confirmation Lambda only adds the caller to their own — but
+        # belt-and-suspenders), we don't claim someone else's tenant as
+        # theirs via the email label.
+        assert (
+            compute_display_name(group="eval-other_user_sub", cognito_sub="abc123", principal="user@example.edu")
+            == "eval-other_user_sub"
+        )
+
+    def test_legacy_principal_without_at_falls_back_to_group(self):
+        # Legacy HS256 path or any JWT where `principal` is a sub (no
+        # email claim available). We can't surface a friendlier label,
+        # so use the group name. The `@` heuristic is what tells us
+        # whether principal is an email or a sub.
+        assert (
+            compute_display_name(
+                group="eval-abc123",
+                cognito_sub="abc123",
+                principal="abc123",  # sub, not email
+            )
+            == "eval-abc123"
+        )
+
+    def test_missing_sub_falls_back_to_group(self):
+        # Without a sub we can't verify the eval-* group is the caller's,
+        # so play it safe and use the group name.
+        assert (
+            compute_display_name(group="eval-abc123", cognito_sub=None, principal="user@example.edu") == "eval-abc123"
+        )
+
+    def test_missing_principal_falls_back_to_group(self):
+        assert compute_display_name(group="eval-abc123", cognito_sub="abc123", principal=None) == "eval-abc123"
+
+
+class TestToWorkspaceItem:
+    """Projection from internal Workspace into the API-facing WorkspaceItem."""
+
+    def test_includes_friendly_display_name_for_personal_tenant(self):
+        ws = Workspace(group="eval-abc123", tenant_schema="tenant_eval_abc123")
+        item = to_workspace_item(ws, cognito_sub="abc123", principal="user@example.edu")
+        assert item.group == "eval-abc123"
+        assert item.tenant_schema == "tenant_eval_abc123"
+        assert item.display_name == "user@example.edu"
+
+    def test_uses_group_name_for_shared_group(self):
+        ws = Workspace(group="lif-team", tenant_schema="tenant_lif_team")
+        item = to_workspace_item(ws, cognito_sub="abc123", principal="user@example.edu")
+        assert item.display_name == "lif-team"
+
+    def test_no_identity_hints_defaults_to_group_name(self):
+        # Callers that don't pass identity context get the same shape they
+        # got pre-#943 (display_name == group).
+        ws = Workspace(group="lif-team", tenant_schema="tenant_lif_team")
+        item = to_workspace_item(ws)
+        assert item.display_name == "lif-team"

--- a/test/components/lif/mdr_services/test_workspace_service.py
+++ b/test/components/lif/mdr_services/test_workspace_service.py
@@ -66,7 +66,12 @@ class TestComputeDisplayName:
         # created `eval-abc123` for them. The user's email is on
         # principal. Display name should be the email.
         assert (
-            compute_display_name(group="eval-abc123", cognito_sub="abc123", principal="user@example.edu")
+            compute_display_name(
+                group="eval-abc123",
+                cognito_sub="abc123",
+                principal="user@example.edu",
+                tenant_schema="tenant_eval_abc123",
+            )
             == "user@example.edu"
         )
 
@@ -74,7 +79,12 @@ class TestComputeDisplayName:
         # User is in lif-team (a shared group). Even though we have the
         # email on principal, the group name is the right friendly label
         # for a shared workspace.
-        assert compute_display_name(group="lif-team", cognito_sub="abc123", principal="user@example.edu") == "lif-team"
+        assert (
+            compute_display_name(
+                group="lif-team", cognito_sub="abc123", principal="user@example.edu", tenant_schema="tenant_lif_team"
+            )
+            == "lif-team"
+        )
 
     def test_eval_group_for_different_sub_does_not_use_email(self):
         # Defense-in-depth: if another user's eval-* group somehow ended
@@ -83,7 +93,12 @@ class TestComputeDisplayName:
         # belt-and-suspenders), we don't claim someone else's tenant as
         # theirs via the email label.
         assert (
-            compute_display_name(group="eval-other_user_sub", cognito_sub="abc123", principal="user@example.edu")
+            compute_display_name(
+                group="eval-other_user_sub",
+                cognito_sub="abc123",
+                principal="user@example.edu",
+                tenant_schema="tenant_eval_other_user_sub",
+            )
             == "eval-other_user_sub"
         )
 
@@ -97,6 +112,7 @@ class TestComputeDisplayName:
                 group="eval-abc123",
                 cognito_sub="abc123",
                 principal="abc123",  # sub, not email
+                tenant_schema="tenant_eval_abc123",
             )
             == "eval-abc123"
         )
@@ -105,11 +121,48 @@ class TestComputeDisplayName:
         # Without a sub we can't verify the eval-* group is the caller's,
         # so play it safe and use the group name.
         assert (
-            compute_display_name(group="eval-abc123", cognito_sub=None, principal="user@example.edu") == "eval-abc123"
+            compute_display_name(
+                group="eval-abc123", cognito_sub=None, principal="user@example.edu", tenant_schema="tenant_eval_abc123"
+            )
+            == "eval-abc123"
         )
 
     def test_missing_principal_falls_back_to_group(self):
-        assert compute_display_name(group="eval-abc123", cognito_sub="abc123", principal=None) == "eval-abc123"
+        assert (
+            compute_display_name(
+                group="eval-abc123", cognito_sub="abc123", principal=None, tenant_schema="tenant_eval_abc123"
+            )
+            == "eval-abc123"
+        )
+
+    def test_empty_principal_after_strip_falls_back_to_tenant_schema(self):
+        # Defense-in-depth per Adam's #947 review: if the resolved
+        # candidate is whitespace-only (a principal of "  " somehow
+        # passed the `@` check, etc.), fall through to tenant_schema
+        # rather than emit an empty display_name. The wire contract
+        # promises `display_name` is non-empty.
+        assert (
+            compute_display_name(
+                group="eval-abc123",
+                cognito_sub="abc123",
+                principal=" @ ",  # whitespace + @ would pass the heuristic but strip to nothing useful
+                tenant_schema="tenant_eval_abc123",
+            )
+            # principal " @ " stripped is "@" — not empty, so it's used as-is.
+            # The fallback only kicks in when the candidate is truly empty
+            # after strip. The exact behavior here is documented: we don't
+            # over-sanitize, just guarantee non-empty.
+            == "@"
+        )
+
+    def test_empty_group_falls_back_to_tenant_schema(self):
+        # Sanity: if a group somehow sanitized to empty string (the
+        # listing pipeline filters these out before this point, but
+        # belt-and-suspenders), tenant_schema is the ultimate fallback.
+        assert (
+            compute_display_name(group="", cognito_sub=None, principal=None, tenant_schema="tenant_lif_team")
+            == "tenant_lif_team"
+        )
 
 
 class TestToWorkspaceItem:


### PR DESCRIPTION
## Summary

Adds a `display_name` field to the workspace listing surface so the SPA picker shows a human-friendly label instead of `eval-<cognito-sub>` for a user's own personal tenant. Resolves the most-visible piece of #943.

For each workspace:

| Workspace | `display_name` |
|---|---|
| `eval-<their-cognito-sub>` (the caller's own personal tenant — verified by matching JWT `sub` against the group suffix) | their email (e.g. `user@example.edu`) |
| `lif-team` and any other shared / invited group | the group name itself |
| Anything else (legacy HS256 callers whose principal is a raw sub, missing context, etc.) | the group name (fallback) |

PM confirmed on the 2026-05-26 call that the `@` character is fine in the UI.

## Surface area

| Layer | Change |
|---|---|
| **`workspace_service.py`** | `WorkspaceItem` gains a required `display_name: str`. New `compute_display_name(group, cognito_sub, principal)`. `to_workspace_item()` now takes optional identity kwargs. |
| **`tenant_endpoints.py`** | `/tenants/mine` + `/tenants/select` thread `cognito_sub` + `principal` from `request.state` through to the projection. `SelectWorkspaceResponse` also carries `display_name` so the SPA can update its mirror immediately on select. |
| **`tenantsService.ts`** | `WorkspaceItem` + `SelectWorkspaceResponse` get `display_name?: string` (optional on the wire so the frontend can deploy ahead of the backend; falls back to `group`). |
| **`Workspaces.tsx`** | Picker card heading shows `display_name ?? group`. Schema name stays as the secondary line per PM ask: *"keep the display of actual schema under workspace name."* |
| **Tests** | New `compute_display_name` + `to_workspace_item` coverage; `/tenants/mine` + `/tenants/select` tests updated; new test for the eval-<sub> → email replacement. |

## Verification

- [x] `uv run pytest test/components/lif/mdr_services/test_workspace_service.py test/bases/lif/mdr_restapi/test_tenant_endpoints.py` — **56 passed**
- [x] `uv run ruff check` + `uv run ruff format` — clean
- [x] `uv run ty check` (touched files) — clean
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] `npx vite build` — 499 modules, no errors

## Out of scope here (follow-ups)

- **Header badge** (PR #944) still shows `group`. After both PRs merge it's a 1-line change to switch to `display_name` — easier as a tiny follow-up than a merge conflict here.
- **Admin-controlled per-group display labels** (e.g. rename `lif-team` to "LIF Internal"). Future work; not requested for the demo.

Auto-deploys to dev frontend on merge via `lif_mdr_frontend.yml`. Backend deploys via the standard `aws-deploy.sh -s dev --only-stack dev-lif-mdr-api` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)