### PR TITLE
Fix: include public in tenant search_path so PG enum types resolve

### DIFF
--- a/components/lif/mdr_utils/database_setup.py
+++ b/components/lif/mdr_utils/database_setup.py
@@ -50,7 +50,16 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
     tenant_schema = getattr(request.state, "tenant_schema", None)
     async with async_session() as session:
         if tenant_schema and _TENANT_SCHEMA_RE.match(tenant_schema):
-            await session.execute(text(f'SET search_path TO "{tenant_schema}"'))
+            # Include `public` as a fallback in the search_path so PG-level
+            # user-defined types (e.g. `elementtype`, `datamodelelementtype`
+            # enums defined in V1.1) resolve correctly. `clone_lif_schema`
+            # copies tables but NOT custom types, so a tenant-scoped query
+            # that casts a value to one of those enums (SQLAlchemy generates
+            # `'Entity'::elementtype` etc.) would otherwise fail with
+            # `UndefinedObjectError: type "elementtype" does not exist`.
+            # Tables are still resolved tenant-first; public fall-through
+            # only fires for objects the tenant schema doesn't contain.
+            await session.execute(text(f'SET search_path TO "{tenant_schema}", public'))
         elif tenant_schema:
             logger.error("Refusing to SET search_path to invalid tenant_schema %r", tenant_schema)
             raise HTTPException(

--- a/components/lif/mdr_utils/database_setup.py
+++ b/components/lif/mdr_utils/database_setup.py
@@ -49,6 +49,14 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
     """
     tenant_schema = getattr(request.state, "tenant_schema", None)
     async with async_session() as session:
+        # `SET search_path` persists on the underlying pooled connection
+        # for its entire lifetime. We MUST issue an explicit SET on every
+        # request — including the no-tenant branch below — or a connection
+        # that was checked out for tenant A and returned to the pool would
+        # still have its search_path pointing at tenant A's schema when
+        # the next request (which might bypass tenant routing entirely)
+        # checks it back out. That's a cross-tenant data-leak risk, not
+        # just a correctness annoyance.
         if tenant_schema and _TENANT_SCHEMA_RE.match(tenant_schema):
             # Include `public` as a fallback in the search_path so PG-level
             # user-defined types (e.g. `elementtype`, `datamodelelementtype`
@@ -65,6 +73,12 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal tenant routing error"
             )
+        else:
+            # No tenant routing for this request, but still neutralize any
+            # leftover search_path the pooled connection carried over from
+            # a prior tenant-scoped request. Reset to PG's default so this
+            # branch behaves as if it had a fresh connection.
+            await session.execute(text("SET search_path TO public"))
         yield session
 
 


### PR DESCRIPTION
## Summary

Tenant-scoped queries that compare against PG user-defined types fail because the tenant `search_path` doesn't include `public`, where the enum types live. Add `, public` as a fallback in the search_path.

## Reproducer

`GET /datamodels/with_details/17` (StateU LIF) and `/18` (Org2 LIF) on dev:

```
asyncpg.exceptions.UndefinedObjectError: type "elementtype" does not exist
```

Both are `OrgLIF`-type models that hit `entity_service.py:305` — the `ExtInclusionsFromBaseDM` query joins on `ElementType` (an `elementtype` enum column). SQLAlchemy generates `'Entity'::elementtype` to compare against the literal, and `elementtype` is resolved via search_path.

The browser console shows a "missing CORS header" error because the 500 response path skips the CORS middleware; the actual failure is the DB query.

## Why this surfaced now

`clone_lif_schema()` (V1.3) copies tables via `LIKE INCLUDING ALL` but **does not clone `CREATE TYPE` definitions**. The cloned column on `tenant_lif_team."ExtInclusionsFromBaseDM"` still references `public.elementtype` correctly (via stored OID), but SQLAlchemy-generated casts use the *unqualified* name `elementtype`, and PG resolves that via search_path. Previously the legacy code path queried `public` directly; only now that we're routing tenant-scoped sessions to a non-public schema does the lookup fail.

## Fix

`components/lif/mdr_utils/database_setup.py`:

```diff
-await session.execute(text(f'SET search_path TO "{tenant_schema}"'))
+await session.execute(text(f'SET search_path TO "{tenant_schema}", public'))
```

Tables/views still resolve tenant-first (every tenant has a full clone via `clone_lif_schema`, so the public fall-through never fires for table lookups). PG types resolve from `public` since the tenant schema has none.

## Deferred follow-ups

- Extend `clone_lif_schema` (and the next Flyway migration) to also clone `CREATE TYPE` definitions so tenants are fully self-contained. Then we can drop the public fallback entirely.
- Or qualify the SQLAlchemy enum mappings (`sa.Enum(..., schema="public")`) so generated casts use `public.elementtype` explicitly.

Either path lets us remove `public` from the search_path. Both are out of scope for the demo timeline.

## Demo-blocking

Yes — without this, workshop attendees clicking on StateU LIF or Org2 LIF data models tomorrow get a generic "Network Error" in the UI. Affects any user with tenant routing enabled (all dev users today; all demo users after promotion).

## Test plan

- [x] `uv run pytest test/bases/lif/mdr_restapi/` — 38 passed
- [x] `uv run ruff check` — clean
- [x] No tests pin the exact `SET search_path` string (`grep -rn "SET search_path" test/` empty)
- [ ] Manual on dev after deploy: load StateU LIF / Org2 LIF in the MDR UI → succeeds
- [ ] Verify the original 200 path (LIF root data model, other source schemas) still works (regression check)

Auto-deploys to dev backend on merge (push-to-main rebuilds the MDR API `:latest` image; ECS picks it up on next task restart, can also be forced via `aws-deploy.sh -s dev --only-stack dev-lif-mdr-api --update-ecs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)