### PR TITLE
Header: pull workspace badge to far right + use display_name

### DIFF
--- a/frontends/mdr-frontend/src/components/Header/Header.tsx
+++ b/frontends/mdr-frontend/src/components/Header/Header.tsx
@@ -83,31 +83,11 @@ const Header: React.FC = () => {
           </NavLink>
         </nav>
 
-        {/* Current-workspace indicator + user menu */}
+        {/* User dropdown sits in its natural left-packed position right
+            after the nav; the workspace badge below is pulled out of this
+            Flex and pushed to the far-right edge of the header so it has
+            breathing room (PM ask 2026-05-27: don't crowd the user ID). */}
         <Flex align="center" gap="3">
-          {/* Guard `tenant_schema` defensively. The TypeScript type marks
-              it required, but `currentWorkspace` originates from
-              localStorage — runtime-untyped — so a corrupted or partially-
-              written value could otherwise render the badge with the
-              friendly-name line populated and the schema line blank.
-              Hiding the entire badge in that case is the safer rendering
-              (per Adam Hungerford review note 2026-05-27). */}
-          {currentWorkspace && currentWorkspace.tenant_schema && (
-            <Badge
-              color="iris"
-              variant="soft"
-              size="2"
-              title={`Schema: ${currentWorkspace.tenant_schema}`}
-            >
-              <LayersIcon />
-              <Flex direction="column" align="start" gap="0">
-                <Text size="2" weight="medium">{currentWorkspace.group}</Text>
-                <Text size="1" color="gray" style={{ fontFamily: "monospace" }}>
-                  {currentWorkspace.tenant_schema}
-                </Text>
-              </Flex>
-            </Badge>
-          )}
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               <Button variant="ghost" size="2">
@@ -138,6 +118,46 @@ const Header: React.FC = () => {
             </DropdownMenu.Content>
           </DropdownMenu.Root>
         </Flex>
+
+        {/* Workspace badge: sibling of the user-area Flex, with auto
+            left margin so it pushes to the right edge of header-content
+            (which uses justify-content: flex-start + gap: 2rem). The
+            gap still applies as a minimum spacer between the dropdown
+            and the badge; the auto margin absorbs any remaining slack
+            so the badge always lands at the page's right edge.
+
+            Defensive guard on `tenant_schema`: the TypeScript type marks
+            it required, but `currentWorkspace` originates from
+            localStorage — runtime-untyped — so a corrupted or partially-
+            written value could otherwise render the badge with the
+            friendly-name line populated and the schema line blank.
+            Hiding the entire badge in that case is the safer rendering
+            (Adam Hungerford review note 2026-05-27). */}
+        {currentWorkspace && currentWorkspace.tenant_schema && (
+          <Badge
+            color="iris"
+            variant="soft"
+            size="2"
+            title={`Schema: ${currentWorkspace.tenant_schema}`}
+            style={{ marginLeft: "auto" }}
+          >
+            <LayersIcon />
+            <Flex direction="column" align="start" gap="0">
+              {/* `display_name` (#943) — email for personal tenants, group
+                  name for shared. Backend (#947) guarantees this is non-
+                  empty (compute_display_name falls through to
+                  tenant_schema rather than emit empty). `||` not `??` so
+                  a corrupted runtime value still falls back to `group`
+                  rather than rendering as a blank label. */}
+              <Text size="2" weight="medium">
+                {currentWorkspace.display_name || currentWorkspace.group}
+              </Text>
+              <Text size="1" color="gray" style={{ fontFamily: "monospace" }}>
+                {currentWorkspace.tenant_schema}
+              </Text>
+            </Flex>
+          </Badge>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary

Tiny follow-up after #944, #947, and #949 all landed. Combines two header tweaks that were validated on the dev integration branch but couldn't ride either of the parent PRs cleanly:

1. **Badge to far right.** Pull the workspace badge out of the user-area Flex and place it as a sibling under `header-content` with `marginLeft: auto`. `header-content` uses `justify-content: flex-start` + `gap: 2rem`, so the gap is the minimum spacer between the dropdown and the badge; the auto margin absorbs any remaining slack and pins the badge to the page's right edge. *PM ask 2026-05-27: don't crowd the user ID.*

2. **Badge label uses `display_name`.** `currentWorkspace.display_name || currentWorkspace.group` instead of `.group` alone. Matches the picker (`Workspaces.tsx`). `||` not `??` so an empty-string runtime value still falls back to `group` — same defense-in-depth pattern @ahungerford-unicon flagged on #947.

## What I left alone

- The `&& currentWorkspace.tenant_schema` guard from #944. It's still defending the localStorage cookie mirror, which sits on a porous boundary that the type system can't reach (manual edit, browser extensions, future code paths). Discussion on #947's review thread covers this.

## Verification

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npx vite build` clean (499 modules)
- [x] Same code was running on the dev integration branch during the 2026-05-27 demo — visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)