### PR TITLE
Issue #938: Redact DATABASE_URL password before logging at startup

### DIFF
--- a/components/lif/mdr_utils/database_setup.py
+++ b/components/lif/mdr_utils/database_setup.py
@@ -4,6 +4,7 @@ import mysql.connector
 import os
 import re
 from typing import AsyncGenerator
+from urllib.parse import urlparse, urlunparse
 
 from fastapi import HTTPException, Request, status
 from lif.mdr_utils.logger_config import get_logger
@@ -15,8 +16,39 @@ from sqlalchemy.orm import sessionmaker
 logger = get_logger(__name__)
 
 
+def _redact_url(url: str) -> str:
+    """Mask the password in a SQLAlchemy connection URL for safe logging.
+
+    Returns the URL with the password replaced by ``***`` while preserving
+    scheme, username, host, port, and database. URLs without a password
+    are returned unchanged. Issue #938: the previous startup log emitted
+    the full URL including the credential, exposing the dev/demo DB
+    password to anyone with read access on the shared CloudWatch log
+    group.
+
+    Best-effort: this is only called for logging, so we never want it to
+    raise and take down MDR startup. Any parsing surprise (urlparse on
+    a malformed URL, ``parts.port`` raising on a non-integer port — which
+    happens when an env var was unset and the URL contains the literal
+    string ``None``) returns a sentinel so the log line still emits
+    something operator-readable.
+    """
+    try:
+        parts = urlparse(url)
+        if not parts.password:
+            return url
+        user = parts.username or ""
+        host = parts.hostname or ""
+        netloc = f"{user}:***@{host}"
+        if parts.port:
+            netloc += f":{parts.port}"
+        return urlunparse(parts._replace(netloc=netloc))
+    except ValueError:
+        return "<unparseable-url>"
+
+
 DATABASE_URL = f"postgresql+asyncpg://{os.getenv('POSTGRESQL_USER')}:{os.getenv('POSTGRESQL_PASSWORD')}@{os.getenv('POSTGRESQL_HOST')}:{os.getenv('POSTGRESQL_PORT')}/{os.getenv('POSTGRESQL_DB')}"
-logger.info(f"DATABASE_URL : {DATABASE_URL}")
+logger.info("DATABASE_URL : %s", _redact_url(DATABASE_URL))
 # Create an async engine
 engine = create_async_engine(DATABASE_URL, echo=True)
 

--- a/test/components/lif/mdr_utils/conftest.py
+++ b/test/components/lif/mdr_utils/conftest.py
@@ -1,0 +1,15 @@
+"""Seed dummy env vars so importing `lif.mdr_utils.database_setup` doesn't
+fail at engine-construction time when running these unit tests.
+
+The tests in this directory exercise pure-Python helpers (e.g.
+`_redact_url`); they never actually connect to a database. We just need
+the module-level `DATABASE_URL` + `create_async_engine` calls to succeed.
+"""
+
+import os
+
+os.environ.setdefault("POSTGRESQL_USER", "test")
+os.environ.setdefault("POSTGRESQL_PASSWORD", "test")
+os.environ.setdefault("POSTGRESQL_HOST", "localhost")
+os.environ.setdefault("POSTGRESQL_PORT", "5432")
+os.environ.setdefault("POSTGRESQL_DB", "test")

--- a/test/components/lif/mdr_utils/test_database_setup.py
+++ b/test/components/lif/mdr_utils/test_database_setup.py
@@ -1,0 +1,47 @@
+"""Unit tests for `database_setup._redact_url` — issue #938.
+
+The full `database_setup` module imports SQLAlchemy/asyncpg/etc at import
+time and tries to construct an engine from env vars, so we import the
+helper directly rather than the whole module via the package surface."""
+
+from lif.mdr_utils.database_setup import _redact_url
+
+
+class TestRedactUrl:
+    def test_masks_password_in_typical_postgres_url(self):
+        url = "postgresql+asyncpg://postgres:s3cret!@dbhost.example:5432/mydb"
+        assert _redact_url(url) == "postgresql+asyncpg://postgres:***@dbhost.example:5432/mydb"
+
+    def test_masks_password_with_special_characters(self):
+        # Real dev password observed in CloudWatch had `:`, `}`, `&`, `<`, `$`
+        # in it. urlparse handles percent-encoding; here we use a
+        # representative literal to confirm the redaction doesn't choke.
+        url = "postgresql+asyncpg://postgres:p:%24sw0rd@host:5432/db"
+        redacted = _redact_url(url)
+        assert "p:%24sw0rd" not in redacted
+        assert "postgres:***@host:5432/db" in redacted
+
+    def test_url_without_port_still_redacts(self):
+        url = "postgresql+asyncpg://postgres:s3cret@host/db"
+        # No explicit port — netloc is just user:pass@host. Redacted form
+        # must drop the password but keep everything else.
+        redacted = _redact_url(url)
+        assert "s3cret" not in redacted
+        assert "postgres:***@host" in redacted
+        assert "/db" in redacted
+
+    def test_url_without_password_is_unchanged(self):
+        # IAM-auth style (no password), or local trust auth — we return
+        # the original string rather than mangling it.
+        url = "postgresql+asyncpg://postgres@host:5432/db"
+        assert _redact_url(url) == url
+
+    def test_unparseable_input_does_not_raise(self):
+        # The function is only ever called for logging; if it raises,
+        # MDR startup fails. Return a sentinel string instead so the
+        # log line still emits something operator-readable.
+        # urlparse is famously tolerant — `urlparse("")` returns an
+        # empty ParseResult rather than raising — so this test really
+        # documents the "no exception" guarantee.
+        assert _redact_url("") == ""
+        assert _redact_url("not-a-url") == "not-a-url"


### PR DESCRIPTION
## Summary

`database_setup.py` was logging the full `DATABASE_URL` (with PG password) on every MDR API task startup. Shared CloudWatch retention means anyone with `logs:FilterLogEvents` could recover the dev/demo DB credential. Closes #938.

## Fix

Small `_redact_url(url) -> str` helper using `urlparse`/`urlunparse`:

```diff
-logger.info(f"DATABASE_URL : {DATABASE_URL}")
+logger.info("DATABASE_URL : %s", _redact_url(DATABASE_URL))
```

Output before:
```
DATABASE_URL : postgresql+asyncpg://postgres:sNa22:}33eS$u:b&X_XdZu!v~4<$r.P2@devmdrdb.dev.aws:5432/devMdrDb
```

Output after:
```
DATABASE_URL : postgresql+asyncpg://postgres:***@devmdrdb.dev.aws:5432/devMdrDb
```

Helper is best-effort: any parsing surprise (malformed URL, missing env var producing a non-integer port) returns a `<unparseable-url>` sentinel rather than raising — a logging path should never take down MDR startup.

## Tests

First tests under `test/components/lif/mdr_utils/` (new directory):
- `_redact_url` covers typical password redaction, special characters in the password, no-port URLs, no-password URLs (IAM auth), and unparseable input.
- A small `conftest.py` seeds dummy `POSTGRESQL_*` env vars so importing `database_setup` doesn't fail at engine-construction time (these pure-Python tests never touch a real DB).

`uv run pytest test/components/lif/mdr_utils/` — 5 passed.

## Follow-up (out of scope here)

- **Rotate dev + demo DB passwords.** Previous values are sitting in CloudWatch retention.
- **Audit other LIF services** that share this logging pattern: `graphql_*`, `translator_*`, `advisor_api`, etc. Same pattern, same fix shape.

Both worth filing as separate issues once this lands.

## Risk

Very low. Pure-Python helper added, single log line changed from f-string to lazy-format with redaction. No behavior change for the engine itself — `create_async_engine` still gets the raw `DATABASE_URL` (it needs the credential to actually connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)