### PR TITLE
Issue #948: Surface spam-folder hint on Login page, drop email-body redundancy

### DIFF
--- a/cloudformation/cognito-selfserve.yml
+++ b/cloudformation/cognito-selfserve.yml
@@ -52,8 +52,6 @@ Resources:
           Enter this code on the registration page to complete sign-up. If
           you didn't request this account, no action is needed and the
           account will not be created.
-
-          (If you don't see this in your inbox, please check Spam / Junk.)
       Schema:
         - Name: email
           AttributeDataType: String

--- a/frontends/mdr-frontend/src/pages/Login.tsx
+++ b/frontends/mdr-frontend/src/pages/Login.tsx
@@ -105,8 +105,7 @@ const Login: React.FC = () => {
                   the moment the user is about to bounce to Cognito to sign
                   up and is about to be waiting for that code — rather than
                   inside the email body itself, where it's redundant if they
-                  see the mail and useless if they don't. Issue #948 (@cbeach47
-                  review of #946). */}
+                  see the mail and useless if they don't. Issue #948. */}
               <Text size="1" color="gray" align="center" mt="1">
                 If you're registering, you'll receive a 6-digit code by email.
                 Check your Spam folder if it doesn't arrive within a minute.

--- a/frontends/mdr-frontend/src/pages/Login.tsx
+++ b/frontends/mdr-frontend/src/pages/Login.tsx
@@ -89,14 +89,29 @@ const Login: React.FC = () => {
           )}
 
           {isCognitoEnabled ? (
-            <Button
-              size="3"
-              className="w-full"
-              disabled={isLoading}
-              onClick={handleCognitoLogin}
-            >
-              {isLoading ? "Redirecting..." : "Sign In / Register"}
-            </Button>
+            <>
+              <Button
+                size="3"
+                className="w-full"
+                disabled={isLoading}
+                onClick={handleCognitoLogin}
+              >
+                {isLoading ? "Redirecting..." : "Sign In / Register"}
+              </Button>
+              {/* The Cognito hosted UI sign-up flow emails a 6-digit code,
+                  and Cognito's default sender domain
+                  (no-reply@verificationemail.com) often hits Gmail / Outlook
+                  spam filters. Surface the spam-folder reminder *here* — at
+                  the moment the user is about to bounce to Cognito to sign
+                  up and is about to be waiting for that code — rather than
+                  inside the email body itself, where it's redundant if they
+                  see the mail and useless if they don't. Issue #948 (@cbeach47
+                  review of #946). */}
+              <Text size="1" color="gray" align="center" mt="1">
+                If you're registering, you'll receive a 6-digit code by email.
+                Check your Spam folder if it doesn't arrive within a minute.
+              </Text>
+            </>
           ) : (
             <form onSubmit={handleLegacySubmit}>
               <Flex direction="column" gap="3">


### PR DESCRIPTION
## Summary

@cbeach47's review of #946 noted the spam-folder hint in the verification email body is in the wrong surface area:

> If they are reading the email, then the user doesn't need to be told where to find it. If they cannot find the email, these directions are not helpful... Maybe add the text in parenthesis to the sign up / verify code page instead?

Move the hint to the SPA Login page — the moment the user is about to bounce to Cognito to sign up, and is about to start waiting for the code.

Closes #948.

## Changes

**`frontends/mdr-frontend/src/pages/Login.tsx`** — under the Cognito Sign In / Register button (only when `isCognitoEnabled`, since the legacy username/password flow doesn't email codes):

```tsx
<Text size="1" color="gray" align="center" mt="1">
  If you're registering, you'll receive a 6-digit code by email.
  Check your Spam folder if it doesn't arrive within a minute.
</Text>
```

**`cloudformation/cognito-selfserve.yml`** — drop the now-redundant `(If you don't see this in your inbox, please check Spam / Junk.)` line from the email body. With the SPA hint in place, the email-body version is duplicative.

## Out of scope

The actual sender-address change (`no-reply@verificationemail.com` → `noreply@unicon.net` via SES with DKIM/SPF) is the proper fix — but it needs AWS to grant SES production access (multi-day process). Tracked under #941.

## Verification

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npx vite build` clean
- [ ] Manual on dev: visit `/login`, confirm the hint renders under the Sign In / Register button (Cognito mode); not visible in legacy username/password mode
- [ ] Manual: register a fresh email after the cognito-selfserve stack redeploys, confirm the email body no longer has the spam-folder parenthetical

The frontend portion deploys to dev on merge via `lif_mdr_frontend.yml`. The cognito-selfserve.yml change needs an explicit stack deploy for dev (and for demo when promoting); the new SPA hint is the user-visible value either way, so the cognito change can wait if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)