### PR TITLE
chore: Promote demo image tags to match current dev :latest (2026-05-27)

### DIFF
--- a/cloudformation/demo-lif-advisor-api.params
+++ b/cloudformation/demo-lif-advisor-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_api:2026-03-19-00-07-05-6ef005a"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_api:2026-05-16-02-30-52-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-dagster-code-location.params
+++ b/cloudformation/demo-lif-dagster-code-location.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/dagster_code_location:2026-02-19-18-44-47-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/dagster_code_location:2026-05-16-02-30-42-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-example-data-source-rest-api.params
+++ b/cloudformation/demo-lif-example-data-source-rest-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_example_data_source_rest_api:2026-02-05-17-41-05-09cd17b"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_example_data_source_rest_api:2026-05-16-02-30-43-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org1.params
+++ b/cloudformation/demo-lif-graphql-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-03-12-18-29-01-1fcb0df"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org2.params
+++ b/cloudformation/demo-lif-graphql-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-03-12-18-29-01-1fcb0df"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org3.params
+++ b/cloudformation/demo-lif-graphql-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-03-12-18-29-01-1fcb0df"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql.params
+++ b/cloudformation/demo-lif-graphql.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-03-12-18-29-01-1fcb0df"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-mariadb-org1.params
+++ b/cloudformation/demo-lif-identity-mapper-mariadb-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-02-19-18-44-41-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-05-16-02-36-50-893562b"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-mariadb-org2.params
+++ b/cloudformation/demo-lif-identity-mapper-mariadb-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-02-19-18-44-41-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-05-16-02-36-50-893562b"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-mariadb-org3.params
+++ b/cloudformation/demo-lif-identity-mapper-mariadb-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-02-19-18-44-41-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-05-16-02-36-50-893562b"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-org1.params
+++ b/cloudformation/demo-lif-identity-mapper-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-02-19-18-44-49-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-05-16-02-30-50-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-org2.params
+++ b/cloudformation/demo-lif-identity-mapper-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-02-19-18-44-49-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-05-16-02-30-50-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-org3.params
+++ b/cloudformation/demo-lif-identity-mapper-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-02-19-18-44-49-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-05-16-02-30-50-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-04-17-01-26-19-64a2b7f"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-05-27-17-25-57-2db4ab9"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mongodb-org1.params
+++ b/cloudformation/demo-lif-mongodb-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-01-29-06-11-01-00cd5b3"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-05-16-03-35-18-1281643"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mongodb-org2.params
+++ b/cloudformation/demo-lif-mongodb-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-01-29-06-11-01-00cd5b3"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-05-16-03-35-18-1281643"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mongodb-org3.params
+++ b/cloudformation/demo-lif-mongodb-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-01-29-06-11-01-00cd5b3"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-05-16-03-35-18-1281643"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mongodb.params
+++ b/cloudformation/demo-lif-mongodb.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-01-29-06-11-01-00cd5b3"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/mongodb:2026-05-16-03-35-18-1281643"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-orchestrator.params
+++ b/cloudformation/demo-lif-orchestrator.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_orchestrator:2026-02-19-18-44-46-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_orchestrator:2026-05-16-02-30-45-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache-org1.params
+++ b/cloudformation/demo-lif-query-cache-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-02-19-18-44-52-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache-org2.params
+++ b/cloudformation/demo-lif-query-cache-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-02-19-18-44-52-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache-org3.params
+++ b/cloudformation/demo-lif-query-cache-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-02-19-18-44-52-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache.params
+++ b/cloudformation/demo-lif-query-cache.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-02-19-18-44-52-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner-org1.params
+++ b/cloudformation/demo-lif-query-planner-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-02-19-18-44-47-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner-org2.params
+++ b/cloudformation/demo-lif-query-planner-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-02-19-18-44-47-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner-org3.params
+++ b/cloudformation/demo-lif-query-planner-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-02-19-18-44-47-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner.params
+++ b/cloudformation/demo-lif-query-planner.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-02-19-18-44-47-f6a18b7"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-semantic-search.params
+++ b/cloudformation/demo-lif-semantic-search.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_semantic_search_mcp_server:2026-03-12-18-29-20-1fcb0df"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_semantic_search_mcp_server:2026-05-16-02-31-25-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-translator-org1.params
+++ b/cloudformation/demo-lif-translator-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_translator_api:2026-03-12-18-29-00-1fcb0df"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_translator_api:2026-05-16-02-30-44-ed0a22e"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
## Summary

Standard outcome of running `./scripts/release-demo.sh --apply` after today's full demo-environment promotion. 29 demo CFN param files updated to pin to the dev `:latest` image tags as of 2026-05-27. MDR API specifically targets commit `2db4ab9` (post-#947 / pre-#950).

## What was deployed today

| Step | What | Notes |
|---|---|---|
| 1 | `setup-mdr-api-keys.sh demo --apply` | Created the missing `/demo/mdr-api/MdrAuthServiceApiKeyPostConfirm` + `/demo/mdr-post-confirm/MdrApiKey` SSM params |
| 2 | `release-demo.sh --apply` | **This PR** — param files now reflect current dev :latest |
| 3 | `demo-lif-mdr-api` stack | New task def `mdr-api-demo:7` with POST_CONFIRM secret + tenant routing env vars |
| 4 | `demo-lif-mdr-cognito` stack | Added `LifTeamGroup` (Precedence 10), swapped post-confirm Lambda body, customized verification email |
| 4b | SAM `mdr-database` (Flyway) | Applied V1.2/V1.3/V1.4 migrations — caught and added to the cheatsheet during this promotion (was missing from the TL;DR). `clone_lif_schema` function now exists; `tenant_lif_team` cloned from public |
| 5 | `release-demo-frontend.sh main --apply` | SPA built from main, synced to S3, CloudFront invalidated |
| 6 | Stale-user cleanup | No-op — demo Cognito pool was empty |

## Smoke tests after promotion

```
/datamodels/                  HTTP 200  21 models
/datamodels/with_details/17   HTTP 200  37 entities  (StateU LIF)
/datamodels/with_details/18   HTTP 200  23 entities  (Org2 LIF)
/datamodels/with_details/1    HTTP 200  54 entities  (base LIF, regression)
/tenants/provision            HTTP 200/201 — function exists and is idempotent
```

## Cheatsheet update

The cheatsheet (`docs/operations/guides/884-demo-promotion-cheatsheet.md`, still uncommitted in working tree) had Step 4b missing from the TL;DR. I added it locally. Will commit + share once @bjagg reviews.

## Follow-up

- One leftover smoke-test tenant schema on demo's MDR DB: `tenant_eval_promotion_smoketest_tenant`. I called `/tenants/provision` directly during step 4b verification, which cloned demo's public into a stale schema. Harmless but cluttery; tracked separately for cleanup when there's bastion / psql access (no clean API path exists to drop it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)