### PR TITLE
Issue #917: Pre-signup Lambda rejects disposable email domains

### DIFF
--- a/cloudformation/cognito-selfserve.yml
+++ b/cloudformation/cognito-selfserve.yml
@@ -90,6 +90,7 @@ Resources:
           - Name: verified_email
             Priority: 1
       LambdaConfig:
+        PreSignUp: !GetAtt PreSignUpLambda.Arn
         PostConfirmation: !GetAtt PostConfirmationLambda.Arn
 
   # ---------------------------------------------------------------------------
@@ -313,6 +314,198 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       FunctionName: !Ref PostConfirmationLambda
+      Action: lambda:InvokeFunction
+      Principal: cognito-idp.amazonaws.com
+      SourceArn: !GetAtt UserPool.Arn
+
+  # ---------------------------------------------------------------------------
+  # Pre-Signup Lambda — registration abuse controls (issue #917)
+  #
+  # PR 1 of #917: reject sign-ups from disposable / throwaway email domains.
+  # This is the enforcement-point + config pattern that later PRs extend with
+  # daily/total caps (PG schema count) and an invite-code bypass.
+  #
+  # A Cognito PreSignUp trigger blocks a registration by RAISING — Cognito
+  # surfaces the exception message to the Hosted UI. Returning the event lets
+  # the sign-up proceed. (autoConfirmUser does NOT gate registration; it only
+  # controls auto-confirmation, so it is not used to reject here.)
+  #
+  # The blocklist is a baseline list baked into the function, optionally
+  # extended by an SSM StringList/String parameter so ops can add domains
+  # without a redeploy (issue #917 design decision 4: config adjustable via
+  # SSM). The parameter is intentionally NOT managed by this template so that
+  # manual edits aren't clobbered on the next deploy; the Lambda falls back to
+  # the baseline list when the parameter is absent.
+  # ---------------------------------------------------------------------------
+  PreSignUpLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub ${EnvironmentName}-${ServiceName}-pre-signup
+      Description: >
+        Cognito pre-signup trigger: rejects registrations from disposable
+        email domains (issue #917 PR 1). Baseline blocklist extendable via the
+        /${EnvironmentName}/${ServiceName}-pre-signup/DisposableDomains SSM
+        parameter (optional; falls back to baseline when absent).
+      Runtime: python3.12
+      Handler: index.handler
+      Timeout: 10
+      ReservedConcurrentExecutions: 5
+      Role: !GetAtt PreSignUpLambdaRole.Arn
+      Environment:
+        Variables:
+          DISPOSABLE_DOMAINS_SSM_PARAM: !Sub /${EnvironmentName}/${ServiceName}-pre-signup/DisposableDomains
+      Code:
+        ZipFile: |
+          import logging
+          import os
+          import re
+          import time
+
+          import boto3
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          ssm = boto3.client("ssm")
+
+          DISPOSABLE_DOMAINS_SSM_PARAM = os.environ.get("DISPOSABLE_DOMAINS_SSM_PARAM", "")
+
+          # Baseline blocklist — common disposable / throwaway providers. Kept
+          # deliberately short and obvious; the SSM parameter is the place to
+          # grow it without a redeploy. Domains are compared lowercased.
+          _BASELINE_DISPOSABLE_DOMAINS = frozenset({
+              "mailinator.com",
+              "guerrillamail.com",
+              "guerrillamailblock.com",
+              "sharklasers.com",
+              "10minutemail.com",
+              "temp-mail.org",
+              "tempmail.com",
+              "throwawaymail.com",
+              "yopmail.com",
+              "trashmail.com",
+              "getnada.com",
+              "dispostable.com",
+              "maildrop.cc",
+              "fakeinbox.com",
+              "mailnesia.com",
+              "mohmal.com",
+              "spam4.me",
+              "tempinbox.com",
+              "emailondeck.com",
+              "moakt.com",
+          })
+
+          # Cache the merged set across warm invocations, refreshed every
+          # _CACHE_TTL seconds so an operator's SSM edit is picked up without a
+          # redeploy or waiting for containers to recycle.
+          _CACHE_TTL = 300
+          _disposable_domains = None
+          _cache_loaded_at = 0.0
+
+
+          def _load_disposable_domains():
+              """Baseline blocklist merged with the optional SSM parameter.
+
+              Cached for _CACHE_TTL seconds. Fails open: a missing parameter or
+              an SSM read error never blocks a legitimate sign-up — the baseline
+              list still applies.
+              """
+              global _disposable_domains, _cache_loaded_at
+              now = time.monotonic()
+              if _disposable_domains is not None and now - _cache_loaded_at < _CACHE_TTL:
+                  return _disposable_domains
+
+              domains = set(_BASELINE_DISPOSABLE_DOMAINS)
+              if DISPOSABLE_DOMAINS_SSM_PARAM:
+                  try:
+                      resp = ssm.get_parameter(Name=DISPOSABLE_DOMAINS_SSM_PARAM)
+                      raw = resp["Parameter"]["Value"]
+                      domains.update(
+                          d.strip().lower() for d in re.split(r"[,\s]+", raw) if d.strip()
+                      )
+                  except ssm.exceptions.ParameterNotFound:
+                      logger.info(
+                          "Disposable-domains param %s not set; using baseline list",
+                          DISPOSABLE_DOMAINS_SSM_PARAM,
+                      )
+                  except Exception as e:  # noqa: BLE001 — fail open on config read
+                      logger.warning(
+                          "Could not read disposable-domains param %s: %s; using baseline",
+                          DISPOSABLE_DOMAINS_SSM_PARAM, e,
+                      )
+
+              _disposable_domains = frozenset(domains)
+              _cache_loaded_at = now
+              return _disposable_domains
+
+
+          def _is_disposable(domain, blocked):
+              """True if the domain or any of its parent domains is blocked.
+
+              A bare blocklist entry (mailinator.com) also matches its
+              subdomains (x.mailinator.com) so the obvious wildcard-subdomain
+              bypass is closed. The public suffix alone (e.g. "com") is never
+              matched because the loop stops before the final label.
+              """
+              if domain in blocked:
+                  return True
+              parts = domain.split(".")
+              for i in range(1, len(parts) - 1):
+                  if ".".join(parts[i:]) in blocked:
+                      return True
+              return False
+
+
+          def handler(event, context):
+              """Cognito PreSignUp trigger.
+
+              Raises (blocking the sign-up) when the email's domain is on the
+              disposable blocklist; Cognito relays the message to the Hosted UI.
+              Returns the event unchanged to allow the sign-up.
+              """
+              attributes = event.get("request", {}).get("userAttributes", {})
+              email = (attributes.get("email") or "").strip().lower()
+              # rstrip(".") normalizes the RFC-1034 trailing-dot FQDN form.
+              domain = email.rpartition("@")[2].rstrip(".")
+
+              if domain and _is_disposable(domain, _load_disposable_domains()):
+                  logger.info("Rejecting sign-up from disposable email domain: %s", domain)
+                  raise Exception(
+                      "Registrations from disposable or temporary email domains are "
+                      "not accepted. Please register with a permanent email address."
+                  )
+
+              return event
+
+  PreSignUpLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${EnvironmentName}-${ServiceName}-pre-signup-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: ReadDisposableDomains
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Plain String parameter (not a secret) — no kms:Decrypt needed.
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/${ServiceName}-pre-signup/DisposableDomains
+
+  PreSignUpLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref PreSignUpLambda
       Action: lambda:InvokeFunction
       Principal: cognito-idp.amazonaws.com
       SourceArn: !GetAtt UserPool.Arn

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
         "argsort",
         "Atlan",
         "bjagg",
+        "blocklist",
         "boto",
         "chatbots",
         "checkpointing",

--- a/docs/design/cross-cutting/self-serve-tenant-auth.md
+++ b/docs/design/cross-cutting/self-serve-tenant-auth.md
@@ -39,6 +39,8 @@ Each numbered step is described in detail below.
 
 **Flow:** Cognito hosts the sign-up UI and sends a confirmation email. The SPA frontend uses Authorization Code with PKCE (no client secret, no implicit grant). On successful confirmation, Cognito triggers a **post-confirmation Lambda**.
 
+**Pre-signup abuse controls (issue #917):** A **pre-signup Lambda** runs *before* Cognito creates the user. PR 1 rejects sign-ups from disposable / throwaway email domains. A Cognito pre-signup trigger blocks a registration by **raising** — Cognito relays the exception message to the Hosted UI; returning the event lets sign-up proceed (`autoConfirmUser` does *not* gate registration, so it isn't used to reject). The blocklist is a baseline list baked into the Lambda, optionally extended by an SSM parameter (`/<env>/<service>-pre-signup/DisposableDomains`, comma/whitespace-separated) so ops can add domains without a redeploy. The parameter is **not** managed by CloudFormation (so manual edits aren't clobbered on deploy); when it's absent or unreadable the Lambda fails open to the baseline list. Later PRs of #917 extend this same enforcement point with rolling daily / total caps (PG schema count) and an invite-code bypass.
+
 **What the Lambda does:** Hits the MDR's `POST /tenants/provision` endpoint (authenticated by a service API key, *not* the new user's JWT — they don't have one yet) with the user's Cognito group name. MDR responds idempotently:
 
 - `201 Created` if the schema was newly minted.
@@ -95,6 +97,7 @@ The recipient registers (or signs in) and presents the token to `POST /tenants/i
 | Concern | Path |
 |---|---|
 | Cognito stack | `cloudformation/*-cognito-selfserve*.yml` |
+| Pre-signup Lambda (disposable-email blocklist, #917) | `cloudformation/cognito-selfserve.yml` (inline) + `test/cloudformation/test_pre_signup_lambda.py` |
 | Post-confirmation Lambda | `cloudformation/*-cognito-selfserve*.yml` + Lambda source |
 | Schema cloning SQL | `projects/lif_mdr_database/migrations/V1.4__*.sql` |
 | `provision_tenant` service | `components/lif/mdr_services/tenant_service.py` |

--- a/test/cloudformation/test_pre_signup_lambda.py
+++ b/test/cloudformation/test_pre_signup_lambda.py
@@ -1,0 +1,154 @@
+"""Tests for the Cognito pre-signup Lambda (issue #917 PR 1).
+
+The handler is defined inline in ``cloudformation/cognito-selfserve.yml`` (the
+artifact CloudFormation actually deploys), so we extract that source and
+exercise it directly — keeping a single source of truth rather than a copy that
+can drift from the deployed code.
+
+What matters here is the *decision* logic: a disposable domain must block the
+sign-up by raising, a permanent domain must pass through, and an SSM read
+problem must fail open (never block a legitimate user).
+"""
+
+import os
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import yaml
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "cloudformation" / "cognito-selfserve.yml"
+
+
+class _CfnLoader(yaml.SafeLoader):
+    """YAML loader that tolerates CloudFormation short tags (!Sub, !GetAtt…)."""
+
+
+def _construct_cfn_tag(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_mapping(node)
+
+
+_CfnLoader.add_multi_constructor("!", _construct_cfn_tag)
+
+
+def _pre_signup_source() -> str:
+    template = yaml.load(TEMPLATE.read_text(), Loader=_CfnLoader)
+    return template["Resources"]["PreSignUpLambda"]["Properties"]["Code"]["ZipFile"]
+
+
+def _load_handler(
+    *, ssm_value=None, ssm_error=None, param_not_found=False, param="/dev/mdr-pre-signup/DisposableDomains"
+):
+    """Exec the inline Lambda source with boto3 stubbed; return its namespace.
+
+    ``ssm_value`` populates the parameter value; ``ssm_error`` (an exception
+    instance) makes get_parameter raise it; ``param_not_found`` makes it raise
+    the client's own ParameterNotFound (so the handler's targeted ``except``
+    matches by class identity). Each call execs into a fresh namespace, so the
+    module-level domain cache starts empty every time.
+    """
+    ssm_client = mock.Mock()
+
+    class ParameterNotFound(Exception):
+        pass
+
+    ssm_client.exceptions.ParameterNotFound = ParameterNotFound
+    if param_not_found:
+        ssm_client.get_parameter.side_effect = ParameterNotFound()
+    elif ssm_error is not None:
+        ssm_client.get_parameter.side_effect = ssm_error
+    else:
+        ssm_client.get_parameter.return_value = {"Parameter": {"Value": ssm_value or ""}}
+
+    # SimpleNamespace (not ModuleType) so the .client attribute is set at
+    # construction — keeps the type checker happy and `import boto3` still
+    # resolves it from sys.modules inside the exec'd Lambda source.
+    fake_boto3 = types.SimpleNamespace(client=mock.Mock(return_value=ssm_client))
+
+    namespace: dict = {}
+    with (
+        mock.patch.dict(sys.modules, {"boto3": fake_boto3}),
+        mock.patch.dict(os.environ, {"DISPOSABLE_DOMAINS_SSM_PARAM": param}),
+    ):
+        exec(compile(_pre_signup_source(), "<pre_signup>", "exec"), namespace)
+    return namespace
+
+
+def _event(email: str) -> dict:
+    return {"request": {"userAttributes": {"email": email}}}
+
+
+def test_baseline_disposable_domain_is_rejected():
+    ns = _load_handler()
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("bot@mailinator.com"), None)
+
+
+def test_permanent_domain_passes_through():
+    ns = _load_handler()
+    event = _event("real.person@unicon.net")
+    assert ns["handler"](event, None) is event
+
+
+def test_match_is_case_and_whitespace_insensitive():
+    ns = _load_handler()
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("  Bot@MailInator.COM  "), None)
+
+
+def test_subdomain_of_blocked_domain_is_rejected():
+    # Regression: a bare blocklist entry must also cover its subdomains,
+    # otherwise x@sub.mailinator.com trivially bypasses the filter.
+    ns = _load_handler()
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("bot@inbox.mailinator.com"), None)
+    # ...but the public suffix alone must never match a legitimate address.
+    ok_event = _event("real@my-school.com")
+    assert ns["handler"](ok_event, None) is ok_event
+
+
+def test_trailing_dot_fqdn_is_rejected():
+    # Regression: the RFC-1034 trailing-dot form must not slip past the check.
+    ns = _load_handler()
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("bot@mailinator.com."), None)
+
+
+def test_ssm_extends_the_blocklist():
+    ns = _load_handler(ssm_value="evil-spam.example, another-throwaway.test")
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("x@evil-spam.example"), None)
+    # baseline still applies alongside the SSM additions
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("x@yopmail.com"), None)
+
+
+def test_missing_ssm_param_falls_back_to_baseline():
+    ns = _load_handler(param_not_found=True)
+    # legitimate user still allowed, baseline still enforced
+    ok_event = _event("real@unicon.net")
+    assert ns["handler"](ok_event, None) is ok_event
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("x@mailinator.com"), None)
+
+
+def test_ssm_read_error_fails_open():
+    # An unexpected SSM error must not block legitimate sign-ups.
+    ns = _load_handler(ssm_error=RuntimeError("ssm throttled"))
+    ok_event = _event("real@unicon.net")
+    assert ns["handler"](ok_event, None) is ok_event
+    # baseline list is still applied despite the read failure
+    with pytest.raises(Exception, match="disposable or temporary email"):
+        ns["handler"](_event("x@mailinator.com"), None)
+
+
+def test_missing_email_does_not_crash():
+    ns = _load_handler()
+    event = {"request": {"userAttributes": {}}}
+    assert ns["handler"](event, None) is event


### PR DESCRIPTION
##### Description of Change

**Problem.** Open self-serve MDR registration on a public Cognito pool is a flood / cost target (#917). The first, cheapest layer of defense is rejecting disposable / throwaway email domains.

**Solution.** A Cognito **PreSignUp** trigger (inline Python in `cloudformation/cognito-selfserve.yml`) that rejects such sign-ups. It blocks by **raising** (Cognito relays the message to the Hosted UI; returning the event allows sign-up — `autoConfirmUser` does not gate registration). A baseline blocklist is baked into the Lambda and optionally extended by an SSM parameter `/<env>/<service>-pre-signup/DisposableDomains` (comma/whitespace-separated), cached 300s so operator edits land without a redeploy. Subdomain (`x@inbox.mailinator.com`) and RFC-1034 trailing-dot (`x@mailinator.com.`) forms are covered; the bare public suffix is never matched. IAM grants `ssm:GetParameter` on exactly one parameter ARN, no `kms:Decrypt`, no wildcards.

**Side effects / limitations.** Self-contained — no DB or VPC. The SSM parameter is intentionally **not** CloudFormation-managed so manual edits survive deploys; the Lambda **fails open** to the baseline list if the parameter is absent/unreadable. Rolling daily/total caps, CAPTCHA, invite-code bypass, and tenant TTL are later PRs of #917.

**How to test.** See the Testing section — automated tests exec the inline handler extracted from the template; `aws cloudformation validate-template` confirms the template parses.

##### Related Issues

Part of #917 (PR 1 of 6 — registration abuse + cost controls). Security-review umbrella: #937.

> Not using `Closes #917` deliberately — this is the first of several PRs against that issue.

##### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Infrastructure/deployment change (CloudFormation: new Lambda + role + trigger wiring)
- [x] Documentation update (design-doc note)

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates
- [x] test/ or e2e/
- [x] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)

---

##### Checklist

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] tests are included (unit tests, `test/cloudformation/test_pre_signup_lambda.py`)
- [x] documentation is changed or added (`docs/design/cross-cutting/self-serve-tenant-auth.md`)
- [x] code passes linting checks (`uv run ruff check`)
- [x] code passes formatting checks (`uv run ruff format`)
- [x] code passes type checking (`uv run ty check`)
- [ ] pre-commit hooks have been run successfully — **N/A in this clone: hooks aren't installed.** Ran the equivalents manually: `ruff check`, `ruff format`, `ty check`, `cspell` (added `blocklist` to `cspell.json`), and the full `uv run pytest test` suite (**541 passed**).

##### Testing

- [ ] Manual testing performed — not yet exercised against a live Cognito pool (deploy pending review).
- [x] Automated tests added/updated — 9 tests: reject/allow, subdomain + trailing-dot bypass regressions, case/whitespace normalization, SSM extension, ParameterNotFound fallback, fail-open on SSM error, missing-email. Template validated via `aws cloudformation validate-template`.
- [ ] Integration testing completed

##### Additional Notes

- Reviewed pre-push via a 4-pass review relay (correctness/security → robustness/ops → tests/conventions → synthesis). Findings fixed here: subdomain bypass, trailing-dot bypass, stale cache (added 300s TTL), loose test assertions (added `match=`), missing `test/cloudformation/__init__.py`.
- **Deferred to follow-ups / later #917 PRs** (intentionally out of scope): allow-path logging + CloudWatch metric filter/alarm; documenting the cold-start fail-*closed* path; SSM value hygiene for operator paste-mistakes (`https://`, `user@…`); extracting the matcher into a `components/lif/` brick at PR 2 when DB access for the caps forces packaging. Judged out of scope for a <50-user evaluator tool: `triggerSource` filtering (pool is Cognito-only) and raising reserved concurrency.
