### PR TITLE
Issue #961: Tenant-isolation tests for get_session search_path routing

### DIFF
--- a/components/lif/mdr_utils/database_setup.py
+++ b/components/lif/mdr_utils/database_setup.py
@@ -90,6 +90,21 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
         # checks it back out. That's a cross-tenant data-leak risk, not
         # just a correctness annoyance.
         if tenant_schema and _TENANT_SCHEMA_RE.match(tenant_schema):
+            # Fail closed if the resolved tenant schema doesn't exist (#961).
+            # PG does NOT error on a missing schema in `SET search_path` — it
+            # silently skips it and resolves everything against the `public`
+            # fallback below, which would serve wrong/empty data instead of
+            # surfacing a provisioning failure (cf. the 2026-05-26 silent
+            # provision-failure). Verify existence first and deny otherwise.
+            # Parameterized — never interpolate the schema into this query.
+            schema_exists = await session.execute(
+                text("SELECT 1 FROM information_schema.schemata WHERE schema_name = :schema"), {"schema": tenant_schema}
+            )
+            if schema_exists.first() is None:
+                logger.error("Resolved tenant schema %r is not provisioned; denying request", tenant_schema)
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Tenant schema not provisioned"
+                )
             # Include `public` as a fallback in the search_path so PG-level
             # user-defined types (e.g. `elementtype`, `datamodelelementtype`
             # enums defined in V1.1) resolve correctly. `clone_lif_schema`
@@ -99,6 +114,10 @@ async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
             # `UndefinedObjectError: type "elementtype" does not exist`.
             # Tables are still resolved tenant-first; public fall-through
             # only fires for objects the tenant schema doesn't contain.
+            # NOTE: this means a tenant schema that EXISTS but is missing a
+            # given table still falls through to public for that table — the
+            # clean fix (copy PG types into tenant schemas, then drop the
+            # `public` fallback) is tracked as a follow-up under #949/#961.
             await session.execute(text(f'SET search_path TO "{tenant_schema}", public'))
         elif tenant_schema:
             logger.error("Refusing to SET search_path to invalid tenant_schema %r", tenant_schema)

--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,9 @@
     "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     "flagWords": [],
     "words": [
+        "elementtype",
+        "datamodelelementtype",
+        "unparseable",
         "abstra",
         "adrs",
         "argsort",

--- a/test/components/lif/mdr_utils/test_database_setup.py
+++ b/test/components/lif/mdr_utils/test_database_setup.py
@@ -1,10 +1,21 @@
-"""Unit tests for `database_setup._redact_url` — issue #938.
+"""Unit tests for `database_setup` — `_redact_url` (#938) and the per-request
+`get_session` search_path routing (#961, tenant isolation).
 
 The full `database_setup` module imports SQLAlchemy/asyncpg/etc at import
-time and tries to construct an engine from env vars, so we import the
-helper directly rather than the whole module via the package surface."""
+time and tries to construct an engine from env vars; the sibling `conftest.py`
+seeds dummy env so the import (and engine construction) succeeds without a DB.
+The `get_session` tests patch `async_session`, so no real connection is made."""
 
-from lif.mdr_utils.database_setup import _redact_url
+# cspell:ignore mydb dbhost cret unparseable agen sw0rd
+
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from lif.mdr_utils import database_setup
+from lif.mdr_utils.database_setup import _redact_url, get_session
 
 
 class TestRedactUrl:
@@ -45,3 +56,76 @@ class TestRedactUrl:
         # documents the "no exception" guarantee.
         assert _redact_url("") == ""
         assert _redact_url("not-a-url") == "not-a-url"
+
+
+def _make_request(tenant_schema):
+    """Minimal stand-in for the FastAPI Request `get_session` reads."""
+    return types.SimpleNamespace(state=types.SimpleNamespace(tenant_schema=tenant_schema))
+
+
+def _patch_session(monkeypatch):
+    """Patch `async_session` so `get_session` runs without a real DB.
+
+    Returns the mock session whose `.execute` records the SQL it was handed.
+    """
+    session = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = session
+    ctx.__aexit__.return_value = False
+    monkeypatch.setattr(database_setup, "async_session", MagicMock(return_value=ctx))
+    return session
+
+
+def _executed_sql(session):
+    return [str(call.args[0]) for call in session.execute.call_args_list]
+
+
+async def _drive(request):
+    """Run `get_session` like a FastAPI dependency: enter, yield, close."""
+    agen = get_session(request)
+    await agen.__anext__()
+    await agen.aclose()
+
+
+class TestGetSessionSearchPath:
+    """#961 — the per-request `SET search_path` is the *entire* tenant-isolation
+    boundary, so lock its behavior: route tenant-first, fail closed on anything
+    the sanitizer wouldn't emit, and always reset (pooled connections persist
+    search_path across requests)."""
+
+    async def test_valid_tenant_routes_tenant_first_then_public(self, monkeypatch):
+        session = _patch_session(monkeypatch)
+        await _drive(_make_request("tenant_acme"))
+        # public is last so PG-level types resolve, but tables resolve tenant-first.
+        assert _executed_sql(session) == ['SET search_path TO "tenant_acme", public']
+
+    async def test_no_tenant_resets_to_public(self, monkeypatch):
+        # A non-tenant request MUST still issue a SET — otherwise a pooled
+        # connection last used for tenant A would leak A's schema into this
+        # request. This is the cross-tenant-leak regression guard.
+        session = _patch_session(monkeypatch)
+        await _drive(_make_request(None))
+        assert _executed_sql(session) == ["SET search_path TO public"]
+
+    @pytest.mark.parametrize(
+        "malicious",
+        [
+            'tenant_a"; DROP SCHEMA public CASCADE; --',  # injection via the schema name
+            'public", "tenant_b',  # smuggle a second schema into the SET
+            "tenant_a, tenant_b",  # comma — widen search_path to another tenant
+            "tenant a",  # space
+            "1tenant",  # leading digit (pattern requires letter/underscore first)
+            "a" * 64,  # 64 chars — exceeds the 63-char identifier cap
+            "tenant_a'; SELECT 1",  # quote-based injection
+        ],
+    )
+    async def test_malformed_or_injection_schema_fails_closed(self, monkeypatch, malicious):
+        # A tenant_schema the sanitizer would never emit means a resolver bug or
+        # a tampered value — fail the request (500) rather than route it, and
+        # crucially do so BEFORE any SET runs so no injected SQL executes.
+        session = _patch_session(monkeypatch)
+        agen = get_session(_make_request(malicious))
+        with pytest.raises(HTTPException) as exc_info:
+            await agen.__anext__()
+        assert exc_info.value.status_code == 500
+        assert session.execute.await_count == 0

--- a/test/components/lif/mdr_utils/test_database_setup.py
+++ b/test/components/lif/mdr_utils/test_database_setup.py
@@ -63,12 +63,17 @@ def _make_request(tenant_schema):
     return types.SimpleNamespace(state=types.SimpleNamespace(tenant_schema=tenant_schema))
 
 
-def _patch_session(monkeypatch):
+def _patch_session(monkeypatch, schema_exists=True):
     """Patch `async_session` so `get_session` runs without a real DB.
 
-    Returns the mock session whose `.execute` records the SQL it was handed.
+    `schema_exists` controls what the `information_schema.schemata` existence
+    probe returns (`.first()` → a row when True, else None). Returns the mock
+    session whose `.execute` records the SQL it was handed.
     """
     session = AsyncMock()
+    result = MagicMock()
+    result.first.return_value = (1,) if schema_exists else None
+    session.execute.return_value = result
     ctx = AsyncMock()
     ctx.__aenter__.return_value = session
     ctx.__aexit__.return_value = False
@@ -93,11 +98,25 @@ class TestGetSessionSearchPath:
     the sanitizer wouldn't emit, and always reset (pooled connections persist
     search_path across requests)."""
 
-    async def test_valid_tenant_routes_tenant_first_then_public(self, monkeypatch):
-        session = _patch_session(monkeypatch)
+    async def test_valid_existing_tenant_routes_tenant_first_then_public(self, monkeypatch):
+        session = _patch_session(monkeypatch, schema_exists=True)
         await _drive(_make_request("tenant_acme"))
-        # public is last so PG-level types resolve, but tables resolve tenant-first.
-        assert _executed_sql(session) == ['SET search_path TO "tenant_acme", public']
+        sql = _executed_sql(session)
+        # Existence is verified first, then routed tenant-first (public last so
+        # PG-level types still resolve).
+        assert any("information_schema.schemata" in s for s in sql)
+        assert sql[-1] == 'SET search_path TO "tenant_acme", public'
+
+    async def test_resolved_but_missing_schema_fails_closed(self, monkeypatch):
+        # #961 part 2: a valid-format schema that isn't provisioned must DENY,
+        # not silently fall through to `public`. The existence probe runs, but
+        # search_path is never pointed at the missing schema.
+        session = _patch_session(monkeypatch, schema_exists=False)
+        agen = get_session(_make_request("tenant_ghost"))
+        with pytest.raises(HTTPException) as exc_info:
+            await agen.__anext__()
+        assert exc_info.value.status_code == 500
+        assert not any("SET search_path" in s for s in _executed_sql(session))
 
     async def test_no_tenant_resets_to_public(self, monkeypatch):
         # A non-tenant request MUST still issue a SET — otherwise a pooled


### PR DESCRIPTION
##### Description of Change

Part 1 of #961 (tenant-isolation): add component tests for the per-request `SET search_path` in `components/lif/mdr_utils/database_setup.py::get_session` — which is the **entire** MDR tenant-isolation boundary. Tests patch `async_session` (no live DB) and assert the SQL the session is handed:

- **valid tenant** → `SET search_path TO "tenant_acme", public` (tenant-first; `public` last only so PG-level types resolve).
- **no tenant** → `SET search_path TO public` — the pooled-connection leak guard (a connection last used for tenant A must not carry A's schema into a non-tenant request).
- **malformed / injection schema names** (embedded quotes/semicolons, comma-smuggled second schema, spaces, leading digit, >63 chars, quote-based injection) → **fail closed** (`HTTP 500`) with **zero** `SET` executed — verifying no injected SQL ever reaches the cursor.

This directly covers #961's "forged/tampered `search_path`" and "SQL-injection through the schema name" adversarial vectors at the routing layer, and locks the existing fail-closed-on-malformed + always-reset behavior against regressions.

##### Scope note (the rest of #961)
Two pieces are **deliberately not** in this PR and remain open under #961 / #937:
1. **Live two-tenant row-isolation integration test** (provision tenants A/B, assert A's cookie can't read B's rows) — needs MDR-Postgres coverage the `integration_tests/` harness doesn't have yet.
2. **`search_path` deny-vs-`public`-fallthrough policy** — a valid-format-but-*missing* schema currently falls through to `public` silently; failing closed there is a production-behavior decision (provisioning-race risk) and the clean posture needs the "copy PG types into tenant schemas, then drop the `public` fallback" migration from #949's notes. Needs a decision before code.

##### Related Issues
Part of #961 (umbrella #937); relates to #949.

##### Type of Change
- [x] Code refactoring (tests only — no runtime change)

##### Project Area(s) Affected
- [x] test/ or e2e/

---

##### Checklist
- [x] commit message follows commit guidelines
- [x] tests are included
- [x] code passes linting / formatting / type checks
- [x] pre-commit hooks have been run successfully (ruff, cspell, ty, pytest)

##### Testing
- [x] `uv run pytest test/components/lif/mdr_utils/test_database_setup.py` — 14 pass (5 pre-existing `_redact_url` + 9 new search_path/injection cases).

##### Additional Notes
No runtime code changed — tests only. The file-scoped `# cspell:ignore` covers test-fixture tokens (`mydb`, `dbhost`, etc.) that were never cspell-clean locally (GitHub squash-merges skip the local hook); chose that over polluting the global dictionary.