### PR TITLE
Add Claude Code skills for LIF Core (dev loop, PR lifecycle, ops, planning)

### DIFF
--- a/.claude/skills/address-pr-feedback/SKILL.md
+++ b/.claude/skills/address-pr-feedback/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: address-pr-feedback
+description: Triage and respond to review feedback on your open LIF Core PRs — pull each PR's reviews + inline comments, apply fixes (or push back with reasoning), reply inline, and re-request review. Appends commits (never force-pushes) and gates outward-facing replies on your confirmation.
+argument-hint: [PR number, or all your open PRs]
+allowed-tools: Read, Edit, Write, Bash, Glob, Grep, Agent
+---
+
+Work the review queue on your open PRs. For each, pull the reviews and **inline** comments (the substance is usually inline, not in the review body), decide per comment whether to fix / clarify / push back, make the changes, reply on the threads, and re-request review.
+
+## Arguments
+
+- `[PR number]` — a single PR. If omitted, sweep **all** your open PRs (`gh pr list --author "@me" --state open`).
+
+## The force-push rule (read first)
+
+**Append commits to PRs under review — never force-push.** Force-pushing invalidates reviewers' "viewed" state and breaks inline-comment threading (AGENTS.md → `feedback_pr_commit_style`). Each round of feedback = one or more new commits, plainly messaged (`Issue #XXX: Address review — <what>`). No rebasing/squashing a PR mid-review unless the reviewer explicitly asks.
+
+## Step 1 — Pull the feedback
+
+```bash
+gh pr list --author "@me" --state open
+# per PR:
+gh pr view <n> --json title,reviewDecision,reviews,comments
+gh api repos/{owner}/{repo}/pulls/<n>/comments \
+  --jq '.[] | {id, author:.user.login, path, line:(.line//.original_line), body, in_reply_to:.in_reply_to_id}'
+```
+The `pulls/<n>/comments` endpoint is the important one — it returns the **inline** review comments (with `suggestion` blocks). The review `body` is often empty; don't stop there. Skip threads where your own latest reply already resolved the point (`in_reply_to` chains).
+
+## Step 2 — Triage each comment
+
+Classify every open (unanswered) comment:
+- **Apply** — a clear fix or an accepted `suggestion` block. Make the edit.
+- **Clarify** — reviewer asked what something means → improve the code/doc *and* answer.
+- **Push back** — the suggestion is wrong or worse. Verify your position in the code first (don't argue from memory), then reply with the reasoning. (Example from a past PR: a `suggestion` that renamed `aget_state`→`agent_state` was a non-existent method — kept the original and explained.)
+- **Defer** — valid but out of scope → file a follow-up issue and reference it in the reply (`Filed #NNN`).
+
+For multi-PR sweeps or large review sets, you can fan out an Agent per PR to draft the triage, but **you** make the edits and own the replies.
+
+## Step 3 — Make the changes & verify
+
+Apply the fixes, then verify before pushing — run the `test` skill or the scoped checks:
+```bash
+uv run pre-commit run --files $(git diff --name-only)
+```
+Commit (append) and push:
+```bash
+git commit -m "Issue #XXX: Address review — <summary>"
+git push                       # plain push, NOT --force
+```
+
+## Step 4 — Reply on the threads  *(outward-facing — confirm first)*
+
+Posting to GitHub is outward-facing. Draft all replies, show them to the user, and post the batch on one confirmation (covers this round, not future ones). Then:
+- **Reply to each inline thread** (so reviewers see the resolution in context):
+  ```bash
+  gh api repos/{owner}/{repo}/pulls/<n>/comments/<comment_id>/replies \
+    -f body="Done — <what changed>, in <commit sha>."
+  ```
+- For accepted `suggestion` blocks, a short "Applied in <sha>" closes the loop.
+- **Re-request review** once the round is addressed:
+  ```bash
+  gh api repos/{owner}/{repo}/pulls/<n>/requested_reviewers -f "reviewers[]=<login>"
+  ```
+  (or `gh pr edit <n> --add-reviewer <login>`). Optionally a brief summary comment: `gh pr comment <n> --body "Addressed all feedback: <bullets>. Re-requesting review."`
+
+## Step 5 — Report
+
+Per PR, report: comments addressed (fixed / clarified / pushed-back / deferred), the commit(s) pushed, replies posted, and whether review was re-requested. Flag any PR still blocked on a decision only the user can make.
+
+## Rules
+
+- **Never force-push a PR under review.** Append commits.
+- **Read the inline comments**, not just the review body — that's where the real feedback lives.
+- **Verify before pushing back.** Check the actual code; don't refute from memory.
+- **Replies/re-requests are outward-facing** — draft, confirm, then post the batch. One confirmation per round.
+- **Don't self-approve** to clear `changes requested` — re-request from the reviewer (CONTRIBUTING review protocol).

--- a/.claude/skills/adr-write/SKILL.md
+++ b/.claude/skills/adr-write/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: adr-write
+description: Draft a new LIF Core ADR. Picks the right domain folder, fills that folder's _template.md, assigns the next per-folder number, and commits. Knows the per-domain-folder, per-folder-numbered ADR layout under docs/design/adr/.
+argument-hint: <short-title-kebab-case>
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+Draft an Architecture Decision Record for LIF Core. ADRs live under [`docs/design/adr/`](../../../docs/design/adr/), **grouped by domain folder** (`general/`, `api/`, `composer/`, `data_model/`, `metadata_repository/`, `orchestrator/`, `query_cache/`, `query_mapper/`, `translator/`, `ai_architecture/`). Each folder numbers its own ADRs sequentially (`0001-…md`, `0002-…md`) and ships its own `_template.md`.
+
+See [`docs/design/adr/README.md`](../../../docs/design/adr/README.md) for the house style (Michael Nygard format).
+
+## Arguments
+
+- `<short-title-kebab-case>` — the filename suffix, e.g. `tenant-search-path-routing`, `advisor-token-streaming`. Becomes `NNNN-<short-title>.md` once numbered.
+
+## Phase 1 — Should this be a new ADR, and in which folder?
+
+1. **Pick the domain folder.** Cross-cutting / foundational decisions go in `general/`. A decision scoped to one service or component goes in that domain's folder. If unsure which folder, ask the user.
+2. **Scan that folder's existing ADRs** (read the closest 1-2 in full). If the decision merely *reverses or supersedes* an existing one, you'll still write a **new** ADR — but plan to mark the old one `Status: Superseded` (with a `References` link) rather than rewriting history. LIF ADRs are a chronological log, not mutable.
+3. **Stop and ask the user** if it's genuinely a refinement that belongs as a small edit to an existing ADR, or if the folder choice is ambiguous: *"This looks like it supersedes `<domain>/NNNN`. New ADR marking that one Superseded, or edit in place? Reasoning: <one line>."* Don't draft until confirmed.
+
+## Phase 2 — Gather decision context
+
+You need four things (from the user or obvious session context). If any is vague, ask before drafting — a vague ADR is worse than none:
+
+1. **Context** — the problem / constraint that prompted the decision. One paragraph.
+2. **Decision** — what was decided. Be specific: name the pattern, data shape, or approach.
+3. **Alternatives** — what else was considered, and why rejected.
+4. **Consequences** — implications and trade-offs, both good and bad. If you can't name a downside, you haven't thought hard enough.
+
+## Phase 3 — Pick the next number (per folder)
+
+Numbering is **per folder**, not global:
+```bash
+ls docs/design/adr/<domain>/ | grep -E "^[0-9]{4}-" | sort -r | head -1
+```
+Next number = highest in that folder + 1 (zero-padded to 4 digits). If the folder has no numbered ADRs yet, start at `0001`. Surface the proposed `<domain>/NNNN` to the user before creating the file.
+
+## Phase 4 — Draft
+
+Copy that folder's template (each domain folder has its own `_template.md`):
+```bash
+cp docs/design/adr/<domain>/_template.md docs/design/adr/<domain>/NNNN-<short-title>.md
+```
+Fill the sections (the LIF template is **Date / Status / Context / Decision / Alternatives / Consequences / References**):
+
+- **Date** — today (`YYYY-MM-DD`).
+- **Status** — `Accepted` if locked; `Proposed` if you want review before it's binding.
+- **Context / Decision** — from Phase 2; specific, not generic.
+- **Alternatives** — at least one real alternative with a one-line "why rejected." Even "do nothing" counts.
+- **Consequences** — at least one positive and one trade-off/risk.
+- **References** — link the related issue(s)/PR(s) and any ADR this supersedes or builds on. If this supersedes another ADR, also edit that ADR's **Status** to `Superseded` and add a back-reference.
+
+## Phase 5 — Index & cross-reference
+
+- If [`docs/INDEX.md`](../../../docs/INDEX.md) inventories ADRs, add the entry (or invoke the `docs-index` skill to keep INDEX in sync).
+- If the decision is load-bearing enough that implementers need it, add a `(see ADR <domain>/NNNN)` reference at the implementing spot in the relevant `docs/design/` or guide doc.
+
+## Phase 6 — Commit
+
+```bash
+git add docs/design/adr/<domain>/NNNN-<short-title>.md
+# plus any superseded ADR + INDEX/cross-ref edits
+git commit -m "docs(adr): add <domain> ADR NNNN — <short title>"
+```
+Surface the file path and commit hash to the user.
+
+## Rules
+
+- **New decisions get new ADRs; supersede, don't rewrite.** Mark the old one `Superseded` and link it.
+- **Numbering is per folder.** `translator/0002` and `composer/0002` coexist — don't globally renumber.
+- **No empty Alternatives / Consequences.** One real row each, minimum.
+- **Write the file before any index/catalog edit** — avoids dangling links if interrupted.
+
+## When NOT to use this skill
+
+- **A pattern already in use** → that's a `docs/design/` architecture doc, not an ADR. ADRs record *decisions*; arch docs describe *current state*.
+- **A design exploration not yet decided** → that's a proposal under [`docs/operations/proposals/`](../../../docs/operations/proposals/) or `docs/proposals/`, not an ADR.

--- a/.claude/skills/issue-sweep/SKILL.md
+++ b/.claude/skills/issue-sweep/SKILL.md
@@ -23,9 +23,11 @@ gh pr list --state merged --limit 60 --json number,title,mergedAt,closingIssuesR
 ```
 Surface the count and the **stalest** issues (oldest `updatedAt`) — those are the richest closure source. Note this repo's convention: merged PRs and `Tracker:`-prefixed commits often reference the resolving issue (`#NNN → PR #MMM`), so resolution evidence usually lives in a merged PR body, a commit `--grep`, or the presence of the named code.
 
+> **Scope deliberately — this sweep is expensive.** Each issue costs ~75K tokens (two judges, each running ~30 `gh`/`git`/`grep` calls). A full open-issue sweep of a large repo (lif-core has 300+ open) is ~20M+ tokens. **Default to a label filter or the stalest ~10–20 issues**, not all-open, unless the user explicitly asks for the whole backlog. Always report the scope you swept (Phase 3) so "nothing else to close" isn't read as "swept everything."
+
 ## Phase 2 — Fan out + arbitrate (Workflow)
 
-Run a Workflow that judges each open issue independently and arbitrates only where the cheap judges disagree. Pass the Phase-1 issue list via `args`. (Invoking this skill is explicit opt-in to the Workflow tool; if Workflow is unavailable, fall back to spawning the Phase-2 agents directly with the Agent tool.)
+Run a Workflow that judges each open issue independently and arbitrates only where the cheap judges disagree. **Inline the Phase-1 issue list directly into the script** as a `const` (see below) — do *not* pass it through the Workflow `args` field; that path has proven unreliable here (the array arrives undefined and `pipeline()` throws). (Invoking this skill is explicit opt-in to the Workflow tool; if Workflow is unavailable, fall back to spawning the Phase-2 agents directly with the Agent tool.)
 
 ```javascript
 export const meta = {
@@ -34,7 +36,11 @@ export const meta = {
   phases: [{ title: 'Judge' }, { title: 'Arbitrate' }],
 }
 
-const issues = args.issues   // [{number, title, labels}], from Phase 1
+// Inline the Phase-1 issue list here (do NOT use args.issues — see note above).
+const issues = [
+  // { number: 75, title: "Add Async support to Advisor API", labels: ["LIF Advisor API"] },
+  // …one entry per issue in scope…
+]
 
 const VERDICT = {
   type: 'object',

--- a/.claude/skills/issue-sweep/SKILL.md
+++ b/.claude/skills/issue-sweep/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: issue-sweep
+description: Multi-agent staleness sweep of open GitHub issues — fan out cheap agents to check which open issues are already resolved by merged PRs / shipped code, arbitrate the uncertain ones, and surface a close-list with evidence. Closing is gated on user confirmation.
+argument-hint: [label or search filter]
+allowed-tools: Bash, Read, Glob, Grep, Agent, Workflow
+---
+
+Find open issues that are **already done**. Shipping velocity outruns issue hygiene, so `lif-core` accumulates open issues that merged PRs or shipped code have quietly resolved. This skill fans out cheap agents to check each open issue against the actual codebase + merged PRs, arbitrates disagreements, and hands you a close-list with evidence. **It never closes an issue without your say-so** — closing/commenting on GitHub is outward-facing.
+
+This is the GitHub-issue analogue of a backlog-drift sweep. Run it after a multi-week arc closes, when catching up on admin, or every ~10 substantive PRs.
+
+## Arguments
+
+- `[filter]` — optional. A label (`"LIF Advisor API"`, `bug`) or `gh issue list --search` query to scope the sweep. Default: all open issues.
+
+## Phase 1 — Survey (inline)
+
+Pull the open issues and recent merged work for context:
+```bash
+gh issue list --state open --limit 200 --json number,title,labels,updatedAt \
+  ${FILTER:+--label "$FILTER"}        # or --search "$FILTER"
+gh pr list --state merged --limit 60 --json number,title,mergedAt,closingIssuesReferences
+```
+Surface the count and the **stalest** issues (oldest `updatedAt`) — those are the richest closure source. Note this repo's convention: merged PRs and `Tracker:`-prefixed commits often reference the resolving issue (`#NNN → PR #MMM`), so resolution evidence usually lives in a merged PR body, a commit `--grep`, or the presence of the named code.
+
+## Phase 2 — Fan out + arbitrate (Workflow)
+
+Run a Workflow that judges each open issue independently and arbitrates only where the cheap judges disagree. Pass the Phase-1 issue list via `args`. (Invoking this skill is explicit opt-in to the Workflow tool; if Workflow is unavailable, fall back to spawning the Phase-2 agents directly with the Agent tool.)
+
+```javascript
+export const meta = {
+  name: 'issue-sweep',
+  description: 'Judge whether each open GitHub issue is already resolved by merged code',
+  phases: [{ title: 'Judge' }, { title: 'Arbitrate' }],
+}
+
+const issues = args.issues   // [{number, title, labels}], from Phase 1
+
+const VERDICT = {
+  type: 'object',
+  properties: {
+    status: { type: 'string', enum: ['resolved', 'open', 'uncertain'] },
+    evidence: { type: 'string', description: 'merged PR #, commit SHA, file/symbol, or why still open' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+  },
+  required: ['status', 'evidence', 'confidence'],
+}
+
+const judgePrompt = (issue) => `Decide whether this OPEN GitHub issue is already RESOLVED by code/PRs that have shipped to LIF Core.
+
+Issue #${issue.number}: ${issue.title}
+Labels: ${(issue.labels || []).join(', ')}
+
+Investigate with:
+- gh issue view ${issue.number}  (read the body + comments + any linked PRs)
+- gh pr list --state merged --search "${issue.number}"  (a PR that closed/referenced it)
+- git log --oneline --grep "#${issue.number}"  and  git log -S "<headline symbol>"  (commit evidence)
+- grep/Glob for the feature's headline keywords / named files/functions to confirm the code exists
+
+Return status=resolved ONLY with concrete evidence (a merged PR #, a commit SHA, or a named shipped file/symbol). status=open if it's clearly not done. status=uncertain if the evidence is ambiguous. Put the evidence (or the reason it's still open) in the evidence field.`
+
+const results = await pipeline(
+  issues,
+  // Stage 1: two independent cheap judges per issue
+  (issue) => parallel([
+    () => agent(judgePrompt(issue), { label: `judge:#${issue.number}:a`, phase: 'Judge', schema: VERDICT, model: 'haiku' }),
+    () => agent(judgePrompt(issue), { label: `judge:#${issue.number}:b`, phase: 'Judge', schema: VERDICT, model: 'haiku' }),
+  ]).then(vs => ({ issue, votes: vs.filter(Boolean) })),
+  // Stage 2: arbitrate only when the two judges disagree on status
+  ({ issue, votes }) => {
+    const statuses = new Set(votes.map(v => v.status))
+    if (statuses.size <= 1) return { issue, verdict: votes[0], votes }
+    return agent(
+      `Two judges disagreed on whether issue #${issue.number} ("${issue.title}") is resolved.\n` +
+      votes.map((v, i) => `Judge ${i + 1}: ${v.status} — ${v.evidence} (${v.confidence})`).join('\n') +
+      `\nInvestigate the same way (gh issue view, merged PRs, git log, code presence) and return the final verdict.`,
+      { label: `arbiter:#${issue.number}`, phase: 'Arbitrate', schema: VERDICT, model: 'sonnet' }
+    ).then(verdict => ({ issue, verdict, votes }))
+  }
+)
+
+return results.filter(Boolean)
+```
+
+## Phase 3 — Report & (only on confirmation) close
+
+Build a table from the Workflow result:
+
+| Issue | Title | Verdict | Confidence | Evidence |
+|-------|-------|---------|-----------|----------|
+| #NNN | … | resolved | high | merged PR #MMM |
+
+- Group **resolved/high-confidence** (the close-list) separately from **uncertain** (needs a human look) and **open** (left alone).
+- **Do not close anything yet.** Present the close-list and ask the user which to act on. For each they approve, offer to:
+  ```bash
+  gh issue close <n> --comment "Resolved by <PR/commit>. Closed via issue-sweep."
+  ```
+  Cite the specific evidence in the closing comment. Closing + commenting are outward-facing — one confirmation covers the approved batch, not future runs.
+- **Report what was skipped** — if the sweep was scoped by a filter or capped at a `--limit`, say so, so "nothing else to close" isn't read as "swept everything."
+
+## Rules
+
+- **Evidence or it didn't resolve.** `resolved` requires a concrete merged PR #, commit SHA, or named shipped symbol — never a vibe.
+- **Stale ≠ resolved.** An old `updatedAt` flags an issue *to check*, not to close.
+- **Never auto-close.** The close-list is a proposal; the user decides.

--- a/.claude/skills/multi-agent-plan/SKILL.md
+++ b/.claude/skills/multi-agent-plan/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: multi-agent-plan
+description: Iteratively design a multi-layer LIF Core feature via a Workflow that runs sequential Opus Plan agents, each refining the prior version through one lens (FP/Polylith → backend correctness → frontend/holistic). Writes v1–v4 plan files to .claude/plans/<feature>-vN.md.
+argument-hint: <feature-name-kebab-case>
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Workflow, Agent
+---
+
+Design a multi-layer feature by running a **Workflow** that pipelines sequential Opus `Plan` agents. Each agent reads the prior version and refines it through **one lens**. The output is an implementation-ready v4 plan. Invoking this skill is explicit opt-in to the Workflow tool.
+
+## Arguments
+
+- `<feature-name>` — kebab-case (e.g. `advisor-token-streaming`, `mdr-output-validation`, `tenant-search-path-routing`).
+
+## When to use
+
+Use when ALL of these hold:
+- The feature spans **2+ layers** (component logic + a base/API + a frontend + migrations/seed).
+- The **data shape is novel** (not a mechanical extension of an existing one).
+- The pattern will be **adopted in more than one place** (multiple services, both frontends, multiple orgs).
+
+Skip when:
+- Single-layer change (one handler, one component function).
+- Bug fix where the shape is already known.
+- Small UX/copy polish.
+
+## Pre-flight (do this inline, before the Workflow)
+
+1. **Confirm scope with the user.** This writes ~4 plan files (~2000 lines total). Don't kick off if scope is fuzzy.
+2. **Assemble the "read first" list** the agents will need. Always include [`CLAUDE.md`](../../../CLAUDE.md) and [`ARCHITECTURE.md`](../../../ARCHITECTURE.md). Then add the closest analogues:
+   - The nearest existing proposal under [`docs/operations/proposals/`](../../../docs/operations/proposals/) — these are the canonical multi-layer plan format for LIF.
+   - The relevant component `core.py`, the base/API handler it flows through, and the frontend file (`frontends/lif_advisor_app/` or `frontends/mdr-frontend/`).
+   - [`docs/operations/guides/testing.md`](../../../docs/operations/guides/testing.md) for test conventions.
+3. **Identify the shipped sibling flow** the feature extends (most features extend an existing flow to a new org/service/shape). Knowing it tells the v1 agent what to reuse vs. fork.
+
+## Run the Workflow
+
+Author and run a Workflow with the script below — fill the `<…>` placeholders from pre-flight and pass the feature name + read-list via `args`. The agents are **sequential** (each depends on the prior), so this is a `pipeline` of one item through four stages. `Plan` agents are read-only and return text; the script returns the four bodies, and **you** (the main loop) write the files after it completes.
+
+```javascript
+export const meta = {
+  name: 'multi-agent-plan',
+  description: 'Iteratively refine a LIF Core feature plan through 4 sequential Plan-agent lenses',
+  phases: [
+    { title: 'v1 draft', model: 'opus' },
+    { title: 'v2 FP/Polylith', model: 'opus' },
+    { title: 'v3 backend correctness', model: 'opus' },
+    { title: 'v4 frontend/holistic', model: 'opus' },
+  ],
+}
+
+const F = args.feature          // kebab feature name
+const READ = args.readFirst     // string: bullet list of files to read first
+const DESC = args.description   // one-paragraph feature description
+const SIBLING = args.sibling    // the shipped sibling flow to anchor on
+
+const plan = (lens, prior, extra) => `You are refining a LIF Core implementation plan.
+
+**Feature:** ${F}
+**Description:** ${DESC}
+**Shipped sibling to anchor on:** ${SIBLING}
+
+**Read first (do this before planning):**
+${READ}
+${prior ? `\n**Prior version to refine (treat its settled parts as done — do not redo them):**\n${prior}\n` : ''}
+${extra}
+
+Return ONLY the plan body (markdown). ${prior ? 'Start with a "Refinements vs. prior version" table.' : ''}`
+
+const v1 = await agent(
+  plan('initial draft', null, `
+**Your job — v1, the initial draft.** Mirror the structure of LIF proposals under docs/operations/proposals/:
+1. Scope — in scope / out of scope.
+2. Data model changes — pydantic shapes, DB/schema additions (mind PascalCase entity props / camelCase scalars).
+3. Backend slices — components/lif/* (pure logic) + bases/lif/* (API/IO) + pydantic schemas + any migrations.
+4. Frontend slices — which frontend (lif_advisor_app vs mdr-frontend), components/hooks/util, routing.
+5. Seed / sample-data / config changes (projects/mongodb/sample_data/{org}).
+6. Implementation order — small, independently testable slices.
+7. Open questions for the implementer.
+Keep it ~250–400 lines.`),
+  { label: 'v1', phase: 'v1 draft', agentType: 'Plan', model: 'opus' })
+
+const v2 = await agent(
+  plan('FP + Polylith boundaries', v1, `
+**Your lens — v2 ONLY: functional / data-driven design + Polylith boundaries.** Do NOT do v3 (backend correctness) or v4 (frontend).
+1. Push IO to the base edge; keep components/lif/* pure and testable in isolation.
+2. Replace if/elif dispatch chains with data-driven lookup maps / strategy tables.
+3. pydantic models for data-only shapes; keep dicts only for live handles that can't be validated.
+4. Pure helpers in the right brick — not buried in a handler.
+5. Brick dependency direction: bases depend on components, never the reverse; flag any new brick + its [tool.polylith.bricks] wiring (incl. the 3 Dagster pyproject.toml files if Dagster uses it).
+6. Declarative over imperative; composable over feature-specific.
+End with: "v2 — FP/Polylith pass. [list of changes]".`),
+  { label: 'v2', phase: 'v2 FP/Polylith', agentType: 'Plan', model: 'opus' })
+
+const v3 = await agent(
+  plan('backend correctness', v2, `
+**Your lens — v3 ONLY: backend correctness & rigor.** Do NOT do v4 (frontend).
+1. async correctness — no blocking llm.invoke / sync IO on the event loop (the advisor API runs a SINGLE uvicorn worker; a blocking call stalls every concurrent request). Use async or run_in_threadpool.
+2. Tenant isolation — get_session search_path routing; fail CLOSED on a missing/unknown tenant schema (never silently fall through to public).
+3. pydantic validation at the API boundary; explicit error surface (correct HTTP codes; in-band errors for already-started streaming responses).
+4. DB migration ordering and multi-org behavior (dev = single-org :latest tags; demo = multi-org pinned tags).
+5. Polylith brick registration — every new brick wired in [tool.polylith.bricks] everywhere it's consumed.
+6. Surface 5–8 non-obvious unit/integration test cases v2 missed (test/ mirrors source; integration_tests/ with --skip-unavailable).
+7. Verify assumed helpers actually exist (grep before assuming).
+End with: "v3 — backend correctness pass. [list]".`),
+  { label: 'v3', phase: 'v3 backend correctness', agentType: 'Plan', model: 'opus' })
+
+const v4 = await agent(
+  plan('frontend + holistic', v3, `
+**Your lens — v4: frontend React/TS + final holistic review.**
+1. Auth — fetch bypasses the axios interceptor; share the 401→refresh→retry logic (frontends/lif_advisor_app/src/utils/axios.ts). Use real localStorage keys + VITE_* env (build-time only — coordinated must-match flags hurt; prefer runtime/content-negotiation).
+2. Frontend tests — lif_advisor_app has vitest (npm test); mdr-frontend has NO runner (gate via npm run build / tsc). Name the test cases.
+3. Routing / session restore / lazy rehydration; empty + error states.
+4. Deploy ordering — backend vs frontend first; ECS task-def vs image rebuild; dev :latest → demo pinned promotion.
+5. Integration test additions that catch the deployment-like failure class (e.g. ALB idle-timeout for long responses).
+6. Sequencing / merge-order across any in-flight PRs touching the same files.
+End with: "v4 is implementation-ready. Promote to docs/ after first ship." and "v4 — frontend/holistic pass. [list]".`),
+  { label: 'v4', phase: 'v4 frontend/holistic', agentType: 'Plan', model: 'opus' })
+
+return { v1, v2, v3, v4 }
+```
+
+## After the Workflow returns
+
+1. **Write the four files** (the workflow can't write to disk — you do):
+   ```
+   .claude/plans/<feature-name>-v1.md  … -v4.md
+   ```
+   Create `.claude/plans/` if it doesn't exist.
+2. **Report to the user:**
+   - The v1 → v4 evolution, one line per version naming the key insight each lens added.
+   - The critical path from v4's implementation order (the slice sequence).
+   - Ask: *"Kick off implementation now, or `/clear` and start fresh with v4 as the source of truth?"* (Fresh context is usually better — v4 is self-contained and a long implementation benefits from a clean prompt cache.)
+3. **Promote after ship, not before.** The plan stays in `.claude/plans/` until the feature is live on dev; then move v4 to a `docs/design/` or proposal doc with a Status header pinning the ship date.
+
+## Lessons baked in
+
+- **One lens per pass.** Asking a single agent for FP + correctness + frontend at once yields a long shallow plan; three focused deep passes yield a tight one.
+- **Each agent reads the prior version** and treats its settled parts as done — v3 doesn't redo v2.
+- **Plan agents are read-only.** They return content; the main loop writes files and commits.
+- **The shipped sibling flow is the anchor.** Put it in every agent's read-list.

--- a/.claude/skills/new-microservice/SKILL.md
+++ b/.claude/skills/new-microservice/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: new-microservice
+description: Stand up a new LIF HTTP service end-to-end — Polylith base + project + auth wiring + docker-compose + GitHub Actions + CloudFormation + tests — as an executable checklist with the known pyproject/brick/Docker pitfalls baked in.
+argument-hint: <service-name>
+allowed-tools: Read, Edit, Write, Bash, Glob, Grep, Agent
+---
+
+Add a new microservice the rest of LIF can build, deploy alongside, and call. This is the executable form of [`docs/operations/guides/adding-a-new-microservice.md`](../../../docs/operations/guides/adding-a-new-microservice.md) — **read that guide first**; it is the source of truth and this skill tracks it. This skill adds the workflow gates, the pitfalls, and the verification steps.
+
+## Arguments
+
+- `<service-name>` — snake_case service name (e.g. `roster_sync`, `credential_verify`). Becomes the base `bases/lif/<service-name>/`, project `projects/lif_<service-name>/`, and stack `{env}-lif-<service-with-dashes>`.
+
+## Pre-flight
+
+1. **Read the guide** ([`adding-a-new-microservice.md`](../../../docs/operations/guides/adding-a-new-microservice.md)) and the Polylith / Docker sections of [`CLAUDE.md`](../../../CLAUDE.md).
+2. **Confirm what the service does** and whether it's internal-only (uses `AuthMiddleware` + a service API key) or has a public surface. Pick an unused docker-compose port (check existing services for the assigned range).
+3. **Find the nearest existing service to copy from.** `advisor_restapi` (LangChain-heavy — don't copy its deps), `api_graphql`, `mdr_restapi`, or `semantic_search_mcp_server`. Copy boilerplate (`.dockerignore`, `.gitignore`, `build.sh`, `build-docker.sh`, `Dockerfile2`) verbatim; **never** copy the dependency block wholesale.
+4. **Multi-layer?** If the service has non-trivial reusable logic (a new component), spawn an Opus `Plan` agent and **confirm the plan with the user** before writing code.
+
+## Build steps (mirror the guide's Steps 1–7)
+
+### 1. Base — `bases/lif/<service>/`
+`__init__.py` (exposes `core`), `core.py` (FastAPI app), one or more `*_endpoints.py` route modules.
+- **Logger consistency:** `from lif.logging import get_logger` throughout. Do **not** mix in `lif.mdr_utils.logger_config` (different format).
+- **Auth:** internal-only services use `AuthMiddleware` from `lif.mdr_auth.core` — don't reinvent JWT/API-key handling.
+- `/health-check` returns `HealthCheckResponse` and is in the public allowlist.
+
+### 2. Project — `projects/lif_<service>/`
+`pyproject.toml`, `Dockerfile2`, `build.sh`, `build-docker.sh`, `README.md`.
+- **Trim dependencies to what you actually import.** A REST API usually needs only `fastapi` + `uvicorn` (+ `httpx`/`pyjwt`/a SQL driver if used). **Do not** pull in `langchain`/`langgraph`/`mcp`/`torch` unless the service genuinely uses them — that bloats the image by hundreds of MB.
+- **PEP 440 `~=` gotcha:** `~=0.275` means `>= 0.275, < 1.0`. To pin a minor range write `~=0.275.0`. (This caused a past prod crash — see CLAUDE.md.)
+- **Docker resolves deps from *this project's* `pyproject.toml`, not `uv.lock`.** A dep declared only at the monorepo root is **absent in the image** (the `boto3` landmine). Declare it here.
+- `Dockerfile2`: copy verbatim, change only `PROJECT_NAME`, the `--port`, and the uvicorn target.
+
+### 3. `[tool.polylith.bricks]` — must match actual imports
+List only the bricks your code imports. After the code is written, verify:
+```bash
+grep -rhn '^from lif\.' bases/lif/<service>/ | sort -u
+```
+Every `lif.X` import needs a matching brick line; every brick line needs ≥1 import. No dead entries.
+- **If a Dagster job will use a new component**, add it to `[tool.polylith.bricks]` in **all three** `projects/dagster_*/pyproject.toml` files (per CLAUDE.md), not just the orchestrator.
+
+### 4. Auth wiring (if internal-only)
+- Add `mdr__auth__service_api_key__<service>` to `components/lif/mdr_utils/config.py`.
+- Add it to the `API_KEYS` dict in `components/lif/mdr_auth/core.py` (server-side accept-list — every `AuthMiddleware` service will accept it).
+
+### 5. docker-compose — `deployments/advisor-demo-docker/docker-compose.yml`
+Follow an existing service block: env vars (CORS, `MDR__AUTH__*`, the allowlist for `/health-check` + `/docs`), the chosen port, network(s), and a `/health-check` healthcheck. Don't list service-API-key env vars your service doesn't actually call with.
+
+### 6. CI + CloudFormation
+- **GitHub Actions:** copy `.github/workflows/lif_advisor_api.yml`; set the `paths:` triggers to your project/base/components. Remember **feature branches don't auto-deploy** — dev `:latest` rebuilds only on push-to-main or manual `workflow_dispatch`.
+- **CloudFormation:** add a template under `cloudformation/`, register the stack in `dev.aws` and `demo.aws` (`STACKS` + `STACK_ORDER`). **If this is your first stack, ask the user for a pairing session** — ALB listener priorities and SSM paths are easy to get wrong solo.
+
+### 7. Tests — mirror under `test/`
+At minimum (use `httpx.AsyncClient(transport=ASGITransport(app=app), ...)` in-process — see `test/bases/lif/mdr_restapi/test_tenant_endpoints.py` for the `get_session` override + auth-stub pattern):
+- health-check returns 200 **without** auth
+- an authenticated endpoint returns 401 **without** a key
+- the happy path returns its payload **with** a valid key
+
+## Verify before opening the PR
+
+Run the `test` skill, or at minimum:
+```bash
+uv run ruff check && uv run ruff format --check && uv run ty check
+uv run poly check
+uv run pytest test/bases/lif/<service>/
+```
+Then walk the guide's final checklist (base / project / trimmed deps / brick match / logger consistency / allowlist / auth key / compose / CI / CFN / tests / green checks). Commit with `Issue #XXX: <description>` (the commit convention).

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: open-pr
+description: Open a convention-compliant LIF Core PR — reads AGENTS.md + CONTRIBUTING.md + the PR template (which do NOT auto-load), verifies branch/commits/pre-commit, fills the template (Closes #, type, areas, checklist), and creates the PR. Honors the one-issue-per-PR and no-self-approve rules.
+argument-hint: [issue number]
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+Open a pull request that passes review on the first read. The whole point of this skill: **only `CLAUDE.md` auto-loads** — `AGENTS.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md` carry binding PR rules that you must read explicitly each time, or the PR will miss conventions.
+
+## Arguments
+
+- `[issue number]` — the issue this PR closes (becomes `Closes #N`). If omitted, infer from the branch name / commits and confirm with the user.
+
+## Step 1 — Read the conventions (do not skip)
+
+Read all three now:
+- [`AGENTS.md`](../../../AGENTS.md) — commit format, the append-don't-force-push rule, pre-commit requirement.
+- [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) § Pull Request Guidelines — one-issue-per-PR, descriptive, review protocol.
+- [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) — the body structure you must fill.
+
+## Step 2 — Pre-flight checks
+
+1. **On a feature branch, not `main`:** `git branch --show-current`. If on `main`, create a branch first (`git checkout -b <issue-NNN-short-desc>`).
+2. **One issue, one PR.** Confirm the diff addresses a single issue/task. If it bundles unrelated changes (a fix *and* a feature), stop and tell the user — split it. (CONTRIBUTING is explicit about this.)
+3. **Commits follow `Issue #XXX: Brief description`** (multi-issue: `Issue #123, Issue #456: …`). The commit-msg hook enforces `commitlint.config.mjs`. Check `git log main..HEAD --oneline`.
+4. **Pushed?** `git log origin/<branch>..HEAD --oneline` — push the branch if needed (`git push -u origin <branch>`).
+5. **Checks green:** run the `test` skill, or at minimum:
+   ```bash
+   uv run pre-commit run --files $(git diff main...HEAD --name-only)
+   ```
+   ruff, cspell, ty, pytest must pass. Don't open a PR on a red build.
+
+## Step 3 — Fill the PR body
+
+Compose the body from the template — fill every section, **remove checklist items that don't apply** (the template says so):
+
+- **Description of Change** — what problem it solves, the solution, side effects/limitations, and **how reviewers should test it**. (The relay synthesis from `self-review-relay`, if you ran it, is good source material.)
+- **Related Issues** — `Closes #<n>` (this is what auto-closes the issue on merge).
+- **Type of Change** — check the one(s) that apply (bug fix / feature / breaking / docs / infra / perf / refactor).
+- **Project Area(s) Affected** — check by the actual diff (`git diff main...HEAD --name-only` → map to `bases/`, `components/`, `frontends/`, `cloudformation/`, migrations, etc.).
+- **Checklist** — check the items truly done (lint/format/type/pre-commit; tests included; docs updated; migration + CHANGELOG if schema changed; MIGRATION.md if breaking). Remove the rest.
+- **Testing** — what you actually ran.
+- **Additional Notes** — merge-order coordination if this shares files with other in-flight PRs; rollout/risk notes.
+
+Write the body to a temp file and create the PR:
+```bash
+gh pr create --base main --title "Issue #<n>: <short description>" --body-file /tmp/pr-body.md
+```
+
+## Step 4 — After creating
+
+- **Do NOT approve your own PR** (CONTRIBUTING review protocol) — except trivial typo / docs-only changes, the only self-approve carve-outs. Normal PRs need another contributor.
+- Surface the PR URL to the user.
+- If the change touches the same files as other open PRs, add a **merge-order note** comment so whoever merges second knows what to keep.
+
+## Rules
+
+- **Read AGENTS.md + CONTRIBUTING.md + the template every time** — they don't auto-load, and that's the #1 source of convention misses.
+- **One issue per PR.** Split bundled changes.
+- **Never force-push to set up the PR** — and once it's under review, append commits only (see `address-pr-feedback`); force-pushes break reviewers' "viewed" state and inline threads.
+- **Green before open.** pre-commit (ruff/cspell/ty/pytest) must pass.

--- a/.claude/skills/promote-to-demo/SKILL.md
+++ b/.claude/skills/promote-to-demo/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: promote-to-demo
+description: Promote the current dev build to the demo environment — bump image tags from dev :latest, deploy the ECS stacks, the MDR frontend, and (if migrations changed) the SAM databases. Gates the promotion on explicit user sign-off after a dev check.
+argument-hint: [all|stacks|frontend|sam]
+allowed-tools: Bash, Read, Agent
+---
+
+Promote dev → demo via the safe path. Demo runs **pinned** image tags; dev runs `:latest`. Promotion = copy the current dev tags into `cloudformation/demo-*.params`, deploy the stacks, redeploy the MDR frontend, and migrate the SAM databases only if Flyway SQL changed. This is the executable form of [`docs/operations/guides/demo-environment-update.md`](../../../docs/operations/guides/demo-environment-update.md) — that guide is the source of truth.
+
+**The hard gate:** demo is the stakeholder-facing environment. Do **not** promote until the change has been validated on dev (`*.dev.lif.unicon.net`) — a check by you or the user, not just "it deployed." Stop and get explicit sign-off before Phase 2.
+
+## Arguments
+
+- `all` (default) — image-tag bump → stacks → frontend → SAM-if-needed.
+- `stacks` — just the image-tag bump + ECS stack deploy.
+- `frontend` — just the MDR frontend (S3 + CloudFront).
+- `sam` — just the SAM databases (when Flyway migrations changed).
+
+All commands run from the **repo root** with `AWS_PROFILE=lif` and an active SSO session. Prerequisites: AWS CLI v2, `jq`, `yq`, `docker`, Node 20+, SAM CLI.
+
+## Pre-flight (always)
+
+1. **Confirm dev is validated.** Ask the user to confirm the change works on dev. If they haven't checked, stop — offer to run the `verify` skill against dev first. Per the gate above, an automated smoke is **not** a substitute for a human touching the feature on dev.
+2. **SSO session live:** `AWS_PROFILE=lif aws sts get-caller-identity` — if it errors, tell the user to run `! aws sso login --profile lif`.
+3. **One deploy at a time.** Never run multiple `aws-deploy.sh` invocations in parallel — concurrent runs cause SSO login conflicts (CLAUDE.md).
+4. **SSM parameters exist?** First-ever promotion of a service needs its SSM params (MDR/GraphQL API keys) created or ECS tasks fail to launch. Check the guide's Step 0; surface to the user if a new service is in this batch.
+
+## Phase 1 — Bump image tags (dry-run first)
+
+```bash
+AWS_PROFILE=lif ./scripts/release-demo.sh            # dry-run: shows which demo-*.params change and to what tags
+```
+Show the user the proposed tag changes. On approval:
+```bash
+AWS_PROFILE=lif ./scripts/release-demo.sh --apply
+git diff cloudformation/demo-*.params                # each ImageUrl should now be a timestamped tag, not :latest
+```
+Review the diff with the user before deploying.
+
+## Phase 2 — GATE, then deploy stacks  *(scope: all | stacks)*
+
+**STOP. Confirm sign-off to promote to demo.** Then:
+```bash
+./aws-deploy.sh -s demo                              # deploys all stacks in STACK_ORDER (~34 stacks)
+```
+- One service only: `./aws-deploy.sh -s demo --only-stack demo-lif-<service>`
+- Force restart when the task-def didn't change but you need fresh containers: `./aws-deploy.sh -s demo --update-ecs`
+
+ECS rolls each service to the new image. Watch for failed tasks (see CLAUDE.md § Debugging ECS Services — the dev/demo log group + `describe-services` events).
+
+## Phase 3 — MDR frontend  *(scope: all | frontend)*
+
+The MDR frontend is static (S3 + CloudFront), **not** ECS — deployed separately from a git ref:
+```bash
+AWS_PROFILE=lif ./scripts/release-demo-frontend.sh main           # dry-run: shows SHA, bucket, API URL
+AWS_PROFILE=lif ./scripts/release-demo-frontend.sh main --apply   # worktree build + sync + CloudFront invalidation
+```
+Any ref works (`main`, a tag, a SHA). The script builds in a temp worktree with `VITE_API_URL` pointed at the demo MDR API and cleans up after itself.
+
+## Phase 4 — SAM databases, only if Flyway SQL changed  *(scope: all | sam)*
+
+Skip unless `sam/*/flyway/` has new/changed SQL. Confirm with the user whether migrations changed.
+```bash
+./aws-deploy.sh -s demo --update-sam                 # mdr-database + dagster-database
+```
+- One DB: `cd sam && bash deploy-sam.sh -s ../demo -d mdr-database`
+- **`V1.1` was *replaced* (not a new V1.2)?** Flyway won't re-run it — the DB must be reset (**destroys MDR data**): `AWS_PROFILE=lif ./scripts/reset-mdr-database.sh demo --apply` (dry-run without `--apply`). Confirm with the user first.
+
+## Phase 5 — Verify & record
+
+```bash
+AWS_PROFILE=lif ./scripts/verify-demo-images.sh      # param-file tags vs running ECS tasks
+```
+- Spot-check demo health endpoints / the relevant surface (or run the `verify` skill against demo).
+- **Commit the pinned tags** so the promotion is tracked:
+  ```bash
+  git add cloudformation/demo-*.params
+  git commit -m "Issue #XXX: Update demo image tags to match dev"
+  ```
+  Open a PR per the repo convention.
+
+## Rules
+
+- **No promotion without dev validation + explicit sign-off.** The dev round-trip is the hard gate.
+- **Deploy sequentially** — never parallel `aws-deploy.sh`.
+- **Always dry-run** `release-demo.sh` / `release-demo-frontend.sh` / `reset-mdr-database.sh` and show the diff before `--apply`.
+- **SAM/DB reset destroys data** — confirm explicitly; never run `reset-mdr-database.sh --apply` unprompted.
+- If any step fails, **stop and report** — don't continue down the phase list on a red step.

--- a/.claude/skills/refactor/SKILL.md
+++ b/.claude/skills/refactor/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: refactor
+description: Safe, behavior-preserving refactoring for LIF Core — split bricks, extract helpers, converge patterns — with a verify gate (ruff/ty/pytest/poly) after every atomic change.
+argument-hint: [target file, brick, or description]
+allowed-tools: Read, Edit, Write, Bash, Glob, Grep, Agent
+---
+
+Refactor LIF Core code safely. The core discipline: **one atomic change → verify → repeat**, and **stop and re-plan** the moment a fix feels hacky. Refactors are behavior-preserving and get their own commit(s).
+
+## Arguments
+
+- `<target>` — a file path, brick name, or description (e.g. `components/lif/translator/core.py`, `extract shared search_path helper`, `split advisor_restapi handlers`).
+
+## Pre-Flight
+
+1. **Read the target code** and enough of its callers to understand the full scope before touching anything.
+2. **Anchor on the conventions.** LIF Core has no single `coding-standards.md`; the shape lives in [`CLAUDE.md`](../../../CLAUDE.md) (Development / Polylith / Data conventions), [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) (brick layout + service map), and [`docs/operations/guides/testing.md`](../../../docs/operations/guides/testing.md). The load-bearing rules:
+   - **Polylith boundaries.** `components/lif/*` are pure, testable-in-isolation modules with a `core.py` entrypoint — **no I/O, no deployment code**. `bases/lif/*` wire HTTP/deployment. Keep IO at the base edge; keep transformation pure in components.
+   - **PascalCase entity props / camelCase scalars** in any data shape, seed, `.graphql`, or fixture.
+3. **Name the goal** — what specific problem does this solve? (brick too large, duplicated logic across handlers, IO tangled with logic, competing patterns.)
+4. **Clean working tree** — `git status`. Refactors are their own commit(s), not mixed with feature work.
+5. **Establish the green baseline** before changing anything:
+   ```bash
+   uv run pytest test/ && uv run poly check
+   ```
+   If a frontend is in scope: `cd frontends/lif_advisor_app && npm test` (or `cd frontends/mdr-frontend && npm run build` — mdr has no test runner).
+
+## Refactoring Loop
+
+### Step 1 — Plan
+- List every file/brick created, modified, or deleted.
+- For brick moves/splits: identify the logical groupings and new module names.
+- **Confirm the plan with the user before proceeding.**
+
+### Step 2 — One atomic change
+Do ONE logical change (extract one helper, move one group of functions, rename one brick). Then immediately verify:
+```bash
+uv run ruff check && uv run ty check
+uv run pytest test/components/lif/<brick>/   # or the relevant scope
+uv run poly check                            # if brick structure/deps changed
+```
+- If tests fail, **fix before the next change**.
+- If the fix feels hacky: stop, re-plan — *"knowing everything I know now, what's the clean design?"*
+
+### Step 3 — Repeat
+One change → verify → next change → verify. Never batch multiple steps between verifications.
+
+### Step 4 — Final verification
+```bash
+uv run ruff check && uv run ruff format && uv run ty check
+uv run pytest test/
+uv run poly check
+uv run pytest integration_tests/ --skip-unavailable   # if behavior near a service boundary moved
+```
+
+## Rules
+
+- **Never refactor and add a feature in the same commit.** Behavior-preserving only.
+- **Test count must not drop.** If you delete a test file, its tests move somewhere.
+- **Update every import after a move.** `grep`/`Grep` for the old module path; `uv run poly check` catches most broken brick wiring but not all.
+- **Moving a brick = update `[tool.polylith.bricks]`.** And per [`CLAUDE.md`](../../../CLAUDE.md), bricks used by Dagster must be added to **all three** Dagster `pyproject.toml` files, not just the orchestrator.
+- **One commit per logical step.** Don't squash a multi-step refactor — reviewability matters.
+- **Update docs if structure changed** — [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) for brick/service changes; run the `docs-index` skill if a `docs/` file was added/moved.
+
+## Common patterns
+
+### Split a large brick `core.py`
+1. Identify logical groups (by responsibility / domain).
+2. Create sibling modules within the component; keep `core.py` as the public entrypoint re-exporting them.
+3. Move one group at a time; verify after each.
+4. Update `:require`-equivalent imports and `[tool.polylith.bricks]`.
+
+### Extract a shared helper
+1. Find logic duplicated across 2+ bricks/handlers.
+2. Create or extend the shared component.
+3. Replace one call site at a time; verify after each.
+
+### Pull IO out of a component
+- A `components/lif/*` module doing HTTP/DB/file IO is a boundary violation. Move the IO to the calling `bases/lif/*` layer and leave a pure transform behind. Add a unit test for the now-pure function.
+
+### Converge competing patterns
+- Same work done two ways (e.g. one handler hand-rolls a dict, another uses a pydantic model) → pick the better one and converge. In LIF, prefer pydantic models for data-only shapes; keep dicts only where a value is a live handle that can't be validated (e.g. a held agent instance).
+
+## What NOT to refactor
+
+- **Working code nobody touches.** If it's not broken and not read, leave it.
+- **Code about to be rewritten for a feature.** Do the feature first.
+- **Framework boilerplate** (FastAPI route decorators, pydantic field declarations, Polylith `pyproject` stanzas) — inherently repetitive.

--- a/.claude/skills/self-review-relay/SKILL.md
+++ b/.claude/skills/self-review-relay/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: self-review-relay
+description: Run the 4-pass self-review relay over a diff before opening or finalizing a PR — three independent lenses (correctness/security, robustness/ops, tests/conventions/scope) in parallel, then a synthesis pass that dedupes and sorts into blockers vs. nits. Catches issues before a reviewer does.
+argument-hint: [diff range, default main...HEAD]
+allowed-tools: Read, Glob, Grep, Bash, Agent, Workflow
+---
+
+Run the **self-review relay**: a structured multi-lens pass over your own change before a human reviewer sees it. Three independent lenses run in parallel, then a synthesis pass merges and prioritizes. This is the rigor step that earns the "no blockers" verdict (it's what produced the relay note on PR #978). It complements — does not replace — the built-in `/code-review`: the relay is broader (security + ops + scope, not just correctness) and ends in a ship/hold verdict.
+
+Invoking this skill is explicit opt-in to the Workflow tool. If Workflow is unavailable, spawn the three lens agents directly with the Agent tool (one message, parallel) and synthesize their results yourself.
+
+## Arguments
+
+- `[diff range]` — what to review. Default `main...HEAD` (the PR diff). Accepts any git range, `--staged`, or a path scope.
+
+## Pre-flight
+
+1. **Capture the diff and context** so the agents review facts, not guesses:
+   ```bash
+   git diff main...HEAD --stat
+   git diff main...HEAD
+   git log main...HEAD --oneline
+   ```
+   Note the touched layers (`bases/`, `components/`, `projects/`, `frontends/`, `cloudformation/`, migrations) — the lenses key off them.
+2. **State the intent in one line** (what issue this closes, what it's supposed to do) — the scope lens needs it to judge over/under-reach.
+
+## The relay (Workflow)
+
+Run a Workflow: lenses 1–3 in parallel (a barrier — synthesis needs all three), then the synthesis pass. Pass the diff + intent into each agent's prompt. Lenses inherit the main-loop model (strong); don't downgrade them.
+
+```javascript
+export const meta = {
+  name: 'self-review-relay',
+  description: 'Three parallel review lenses over a diff, then a synthesis/verdict pass',
+  phases: [{ title: 'Lenses' }, { title: 'Synthesis' }],
+}
+
+const DIFF = args.diff       // the unified diff text
+const INTENT = args.intent   // one-line statement of what the change should do
+const RANGE = args.range || 'main...HEAD'
+
+const FINDINGS = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          severity: { type: 'string', enum: ['blocker', 'should-fix', 'nit'] },
+          file: { type: 'string' },
+          line: { type: 'string' },
+          issue: { type: 'string' },
+          suggestion: { type: 'string' },
+        },
+        required: ['severity', 'file', 'issue', 'suggestion'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const lens = (name, focus) => agent(
+  `You are one lens of a self-review relay on a LIF Core change. Review ONLY through this lens: ${name}.
+
+**Intent of the change:** ${INTENT}
+**Diff (${RANGE}):**
+\`\`\`diff
+${DIFF}
+\`\`\`
+
+**Your focus:**
+${focus}
+
+You may read surrounding files (Read/Grep) for context the diff doesn't show. Report concrete findings with file:line, severity (blocker / should-fix / nit), and a specific suggestion. If the lens finds nothing real, return an empty findings array — do NOT invent issues.`,
+  { label: name, phase: 'Lenses', schema: FINDINGS }
+)
+
+const lenses = await parallel([
+  () => lens('correctness & security', `
+- Logic bugs, off-by-one, wrong conditionals, unhandled None/empty, race conditions.
+- Async correctness: no blocking/sync IO on the event loop (advisor API is a SINGLE uvicorn worker — a blocking call stalls all concurrent requests).
+- Tenant isolation: get_session search_path routing; fail CLOSED on missing/unknown tenant schema (never fall through to public).
+- Auth: username/identity from the JWT 'sub', never from user input; AuthMiddleware not bypassed; secrets not logged.
+- Injection / unchecked input at the boundary; pydantic validation present.`),
+  () => lens('robustness & ops', `
+- Error surface: correct HTTP codes; in-band errors once a StreamingResponse has started; no silent fallbacks (e.g. schema-from-MDR must fail loud, not fall back to file in prod).
+- Resource hygiene: connections/readers closed, no leaks; timeouts.
+- Deployment impact: docker-compose / cloudformation / {env}.aws / SSM params consistent; dev :latest vs demo pinned; new env vars documented.
+- Polylith: brick deps wired in [tool.polylith.bricks] (incl. the 3 Dagster pyproject.toml files if Dagster uses it); deps in the project's pyproject for Docker, not just root.
+- Migrations idempotent (V1.2+ re-runnable via psql locally).`),
+  () => lens('tests, conventions & scope', `
+- Tests: regression test for any bug fixed; boundary cases; no importlib.reload(); meaningful (not coverage-for-its-sake).
+- Conventions: PascalCase entities / camelCase scalars in data shapes; lif.logging logger; file layout (pydantic models / helpers / handlers grouped); commit messages 'Issue #XXX:'.
+- Scope: does the diff do exactly what the intent says — nothing extra (sneaked-in refactor/feature), nothing missing (a layer the change implies but skipped)? One-issue-per-PR.
+- Docs: INDEX.md / README / CHANGELOG / MIGRATION.md updated if the change requires it.`),
+])
+
+const all = lenses.filter(Boolean).flatMap(r => r.findings)
+
+const synthesis = await agent(
+  `Synthesize a self-review verdict for a LIF Core change from these lens findings. Intent: ${INTENT}
+
+Findings (JSON):
+${JSON.stringify(all, null, 2)}
+
+Deduplicate overlapping findings, drop any that are wrong or not supported by the diff, and sort by severity. Then give:
+1. A blockers list (must fix before requesting review) — empty is a valid, good answer.
+2. A should-fix list.
+3. A nits list.
+4. A one-line verdict: "ready to request review" or "hold — N blocker(s)".
+Be a skeptic: if a finding looks plausible but you can't tie it to a real line in the diff, cut it.`,
+  { label: 'synthesis', phase: 'Synthesis' }
+)
+
+return { findingCount: all.length, synthesis }
+```
+
+## After the relay
+
+- **Present the synthesis verdict** (blockers / should-fix / nits / ready-or-hold) to the user.
+- **Offer to fix the blockers + should-fix** in the working tree, then re-run the relevant lens or `uv run pytest` to confirm.
+- This pairs with **`open-pr`** — run the relay, clear blockers, then scaffold the PR. The relay's synthesis is good raw material for the PR description's "how to test" / "limitations" sections.
+
+## Rules
+
+- **Blockers gate the PR.** Don't hand off to a human reviewer with known blockers — that's what this pass is for.
+- **Empty findings is a real result.** The lenses must not manufacture issues to look thorough; the synthesis must cut unsupported ones.
+- **The relay reviews; it doesn't ship.** It never pushes or opens a PR — that's `open-pr`.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: test
+description: Run the full LIF Core check suite — ruff, ty, pytest unit, Polylith check, integration, and the advisor-app frontend tests — and report a summary table.
+allowed-tools: Bash
+---
+
+Run the LIF Core quality gate. These are the same checks `pre-commit` runs (ruff, ty, pytest) plus the integration suite, the Polylith workspace check, and the one frontend with a test runner.
+
+## Steps
+
+Run from the repo root. The backend checks are independent — run them, then the frontend.
+
+1. **Lint** — `uv run ruff check`
+2. **Format check** — `uv run ruff format --check` (use `uv run ruff format` to actually fix)
+3. **Type check** — `uv run ty check`
+4. **Polylith workspace check** — `uv run poly check` (catches missing brick deps / broken `[tool.polylith.bricks]` wiring)
+5. **Unit tests** — `uv run pytest test/` (mirrors source: `test/components/`, `test/bases/`; `asyncio_mode = auto`)
+6. **Integration tests** — `uv run pytest integration_tests/ --skip-unavailable`
+7. **Advisor-app frontend** — `cd frontends/lif_advisor_app && npm test` (vitest)
+
+Notes:
+- **Integration tests hit a live stack** and load sample data from `projects/mongodb/sample_data/{org-key}/`. `--skip-unavailable` skips a test when its backing service is unreachable rather than failing — keep it on for local runs. Full reference: [`docs/operations/guides/testing.md`](../../../docs/operations/guides/testing.md).
+- **`mdr-frontend` has no test runner** (its `package.json` scripts are dev/build/lint/preview only). Don't try `npm test` there — for it, fall back to `cd frontends/mdr-frontend && npm run build` (runs `tsc -b`) as the type/build gate. (A vitest harness for it is tracked separately.)
+- **Don't use `importlib.reload()`** to re-run a module under test — it breaks `isinstance()`/`pytest.raises()`. Use `mock.patch.object(module, "VAR", value)`.
+- To scope unit tests to one component: `uv run pytest test/components/lif/<component>/`.
+- The one-shot equivalent of steps 1-3+5 is `uv run pre-commit run --all-files`.
+
+## Reporting
+
+Report a summary table:
+
+| Check | Result | Details |
+|-------|--------|---------|
+| ruff check | pass/fail | lint findings |
+| ruff format | pass/fail | files needing format |
+| ty check | pass/fail | type errors |
+| poly check | pass/fail | brick/dep issues |
+| Unit (pytest test/) | pass/fail | N passed / N failed |
+| Integration | pass/fail | N passed / N skipped (service unavailable) |
+| Advisor-app (vitest) | pass/fail | N tests |
+
+If any check fails, show the relevant error output below the table.

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,8 @@
     "words": [
         "abstra",
         "adrs",
+        "elif",
+        "threadpool",
         "argsort",
         "Atlan",
         "bjagg",

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
         "elif",
         "threadpool",
         "oneline",
+        "aget",
         "argsort",
         "Atlan",
         "bjagg",

--- a/cspell.json
+++ b/cspell.json
@@ -6,6 +6,7 @@
         "adrs",
         "elif",
         "threadpool",
+        "oneline",
         "argsort",
         "Atlan",
         "bjagg",


### PR DESCRIPTION
##### Description of Change

Adds **10 Claude Code skills** under `.claude/skills/` (alongside the existing `docs-index` skill), each encoding a recurring LIF-Core workflow as an executable, convention-aware procedure so they run consistently instead of being re-derived ad hoc each time.

- **What problem it solves:** multi-step workflows (PR lifecycle, ops deploys, planning, issue triage, testing) were done from memory each session, which led to convention misses and rework. These capture the workflow *and* the real LIF-Core footguns (e.g. the 3-Dagster-`pyproject` rule, fail-closed tenant routing, single-uvicorn-worker async, append-don't-force-push, "only `CLAUDE.md` auto-loads").
- **The skills:**
  - **Dev loop:** `test` (ruff/ty/pytest/poly + integration + vitest), `refactor` (atomic-change→verify), `adr-write` (per-domain-folder ADR layout)
  - **PR lifecycle:** `self-review-relay` (multi-lens pre-review pass), `open-pr` (reads AGENTS.md/CONTRIBUTING.md/template, base-branch + fork checks), `address-pr-feedback` (triage + reply + re-request)
  - **Ops / scale:** `new-microservice` (the add-a-service runbook), `promote-to-demo` (dev→demo gated promotion), `multi-agent-plan` (sequential design passes), `issue-sweep` (multi-agent stale-issue audit)
- **Side effects / limitations:** **docs-only** — Markdown skill files + 4 added `cspell.json` words. No application code, runtime, or deployment config is touched. `multi-agent-plan` and `issue-sweep` use the Workflow tool and explain a fallback when it isn't available.
- **How to test:** invoke any skill (e.g. `/test`, `/open-pr`) in a LIF-Core session; `cspell` passes; no code paths are affected.

##### Related Issues

No tracking issue — developer-experience tooling. Happy to file one if the team prefers.

##### Type of Change

- [x] Documentation update

##### Project Area(s) Affected

- [x] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md) — specifically `.claude/skills/`

##### Checklist

- [x] code passes linting checks (`uv run ruff check`) — N/A to Markdown; pre-commit ran clean on every commit
- [x] pre-commit hooks have been run successfully (cspell passed on each commit)
- [x] documentation is changed or added

##### Testing

- [x] Manual testing performed — `cspell` clean; skill frontmatter/structure verified

##### Additional Notes

- Adapted from a sibling repo's skill set, **re-lensed for LIF-Core's stack** (Python/Polylith + FastAPI + React/TS) rather than copied.
- Deliberately **not** ported: a custom `code-review` skill (LIF-Core already has built-in `/code-review` + `/security-review`), plus `session-wrapup` and several domain-specific skills that don't apply here.
