### PR TITLE
Issue #997: Add GHA + AWS deploy config for LDE microservice

### DIFF
--- a/.github/workflows/lif_learner_data_export_api.yml
+++ b/.github/workflows/lif_learner_data_export_api.yml
@@ -1,0 +1,73 @@
+name: Deploy LIF Learner Data Export API to Amazon ECS
+
+env:
+  AWS_REGION: us-east-1
+  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
+  ECS_CLUSTER: dev
+  ECS_SERVICE_ORG1: learner-data-export-api-FARGATE
+
+permissions:
+      id-token: write
+      contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+    paths:
+      - .github/workflows/lif_learner_data_export_api.yml
+      - bases/lif/learner_data_export_api/**
+      - cloudformation/dev-lif-learner-data-export-api.params
+      - cloudformation/lif-learner-data-export-api-taskdef-includes.yml
+      - components/lif/datatypes/**
+      - components/lif/exceptions/**
+      - components/lif/lif_schema_config/**
+      - components/lif/logging/**
+      - components/lif/mdr_auth/**
+      - components/lif/mdr_client/**
+      - components/lif/mdr_dto/**
+      - components/lif/mdr_services/**
+      - components/lif/mdr_utils/**
+      - components/lif/query_planner_client/**
+      - components/lif/tenant_routing/**
+      - components/lif/translator_client/**
+      - projects/lif_learner_data_export_api/**
+
+jobs:
+
+  lif-learner-data-export-api:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      WORKING_DIR: ./projects/lif_learner_data_export_api
+      ECR_REPOSITORY: lif/dev/lif_learner_data_export_api
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Build the project
+      shell: bash
+      working-directory: ${{ env.WORKING_DIR }}
+      run: |
+        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
+        ./build.sh
+
+    - name: Build and push docker image
+      uses: ./.github/actions/build-and-push
+      with:
+        working-dir: ${{ env.WORKING_DIR }}
+        github-actions-role: ${{ env.GHA_ROLE }}
+        role-session-name: learner-data-export-api-build
+        aws-region: ${{ env.AWS_REGION }}
+        ecr-repository: ${{ env.ECR_REPOSITORY }}
+
+    - name: Update the lif-learner-data-export-api ECS Service
+      uses: ./.github/actions/update-cluster
+      with:
+        github-actions-role: ${{ env.GHA_ROLE }}
+        role-session-name: learner-data-export-api-ecs
+        aws-region: ${{ env.AWS_REGION }}
+        ecs-cluster: ${{ env.ECS_CLUSTER }}
+        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}

--- a/cloudformation/demo-lif-learner-data-export-api.params
+++ b/cloudformation/demo-lif-learner-data-export-api.params
@@ -1,0 +1,138 @@
+[
+  {
+    "ParameterKey": "RedshiftSecretArn",
+    "ParameterValue": "notapplicable"
+  },
+  {
+    "ParameterKey": "DomainNames",
+    "ParameterValue": "lde.demo.lif.unicon.net"
+  },
+  {
+    "ParameterKey": "EnvironmentName",
+    "ParameterValue": "demo"
+  },
+  {
+    "ParameterKey": "ServiceName",
+    "ParameterValue": "learner-data-export-api"
+  },
+  {
+    "ParameterKey": "S3AppBucket",
+    "ParameterValue": "/demo/S3Bucket"
+  },
+  {
+    "ParameterKey": "CloudMapPrivateNamespace",
+    "ParameterValue": "/demo/CloudMapPrivateNamespace"
+  },
+  {
+    "ParameterKey": "Priority",
+    "ParameterValue": "3"
+  },
+  {
+    "ParameterKey": "EcsLaunchType",
+    "ParameterValue": "FARGATE"
+  },
+  {
+    "ParameterKey": "HealthCheckUrl",
+    "ParameterValue": "/health"
+  },
+  {
+    "ParameterKey": "UseLbForService",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "InstanceType",
+    "ParameterValue": "t3a.small"
+  },
+  {
+    "ParameterKey": "ECSAMI",
+    "ParameterValue": "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+  },
+  {
+    "ParameterKey": "ImageUrl",
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:latest"
+  },
+  {
+    "ParameterKey": "TaskDefIncludesFile",
+    "ParameterValue": "s3://clir-cf-templates/demo-lif/lif-learner-data-export-api-taskdef-includes.yml"
+  },
+  {
+    "ParameterKey": "TaskRoleIncludesFile",
+    "ParameterValue": "s3://clir-cf-templates/demo-lif/service-taskrole-includes.yml"
+  },
+  {
+    "ParameterKey": "ContainerPort",
+    "ParameterValue": "8013"
+  },
+  {
+    "ParameterKey": "ContainerMemory",
+    "ParameterValue": "1024"
+  },
+  {
+    "ParameterKey": "ContainerCpu",
+    "ParameterValue": "512"
+  },
+  {
+    "ParameterKey": "HealthCheckGracePeriod",
+    "ParameterValue": "300"
+  },
+  {
+    "ParameterKey": "MaxCount",
+    "ParameterValue": "1"
+  },
+  {
+    "ParameterKey": "MinCount",
+    "ParameterValue": "1"
+  },
+  {
+    "ParameterKey": "SecurityGroup",
+    "ParameterValue": "/demo/EcsInstanceSecurityGroup"
+  },
+  {
+    "ParameterKey": "PrivateSubnets",
+    "ParameterValue": "/demo/PrivateSubnets"
+  },
+  {
+    "ParameterKey": "VPC",
+    "ParameterValue": "/demo/VPC"
+  },
+  {
+    "ParameterKey": "EnvironmentKmsKey",
+    "ParameterValue": "/demo/EnvironmentKmsKey"
+  },
+  {
+    "ParameterKey": "EcsCluster",
+    "ParameterValue": "/demo/EcsCluster"
+  },
+  {
+    "ParameterKey": "LoadBalancerListener",
+    "ParameterValue": "/demo/LoadBalancerHttpsListener"
+  },
+  {
+    "ParameterKey": "EfsFileSystemId",
+    "ParameterValue": "/demo/EfsFileSystemId"
+  },
+  {
+    "ParameterKey": "PublicHostedZoneId",
+    "ParameterValue": "/demo/PublicHostedZoneId"
+  },
+  {
+    "ParameterKey": "PublicHostedZoneName",
+    "ParameterValue": "/demo/PublicHostedZoneName"
+  },
+  {
+    "ParameterKey": "LoadBalancerDnsName",
+    "ParameterValue": "/demo/LoadBalancerDnsName"
+  },
+  {
+    "ParameterKey": "LoadBalancerHostedZoneId",
+    "ParameterValue": "/demo/LoadBalancerHostedZoneId"
+  },
+  {
+    "ParameterKey": "RestrictedCIDRs",
+    "ParameterValue": "notapplicable"
+  },
+  {
+    "ParameterKey": "PathPattern",
+    "ParameterValue": "notapplicable"
+  }
+]

--- a/cloudformation/dev-lif-learner-data-export-api.params
+++ b/cloudformation/dev-lif-learner-data-export-api.params
@@ -1,0 +1,138 @@
+[
+  {
+    "ParameterKey": "RedshiftSecretArn",
+    "ParameterValue": "notapplicable"
+  },
+  {
+    "ParameterKey": "DomainNames",
+    "ParameterValue": "lde.dev.lif.unicon.net"
+  },
+  {
+    "ParameterKey": "EnvironmentName",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "ServiceName",
+    "ParameterValue": "learner-data-export-api"
+  },
+  {
+    "ParameterKey": "S3AppBucket",
+    "ParameterValue": "/dev/S3Bucket"
+  },
+  {
+    "ParameterKey": "CloudMapPrivateNamespace",
+    "ParameterValue": "/dev/CloudMapPrivateNamespace"
+  },
+  {
+    "ParameterKey": "Priority",
+    "ParameterValue": "3"
+  },
+  {
+    "ParameterKey": "EcsLaunchType",
+    "ParameterValue": "FARGATE"
+  },
+  {
+    "ParameterKey": "HealthCheckUrl",
+    "ParameterValue": "/health"
+  },
+  {
+    "ParameterKey": "UseLbForService",
+    "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "InstanceType",
+    "ParameterValue": "t3a.small"
+  },
+  {
+    "ParameterKey": "ECSAMI",
+    "ParameterValue": "/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"
+  },
+  {
+    "ParameterKey": "ImageUrl",
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:latest"
+  },
+  {
+    "ParameterKey": "TaskDefIncludesFile",
+    "ParameterValue": "s3://clir-cf-templates/dev-lif/lif-learner-data-export-api-taskdef-includes.yml"
+  },
+  {
+    "ParameterKey": "TaskRoleIncludesFile",
+    "ParameterValue": "s3://clir-cf-templates/dev-lif/service-taskrole-includes.yml"
+  },
+  {
+    "ParameterKey": "ContainerPort",
+    "ParameterValue": "8013"
+  },
+  {
+    "ParameterKey": "ContainerMemory",
+    "ParameterValue": "1024"
+  },
+  {
+    "ParameterKey": "ContainerCpu",
+    "ParameterValue": "512"
+  },
+  {
+    "ParameterKey": "HealthCheckGracePeriod",
+    "ParameterValue": "300"
+  },
+  {
+    "ParameterKey": "MaxCount",
+    "ParameterValue": "1"
+  },
+  {
+    "ParameterKey": "MinCount",
+    "ParameterValue": "1"
+  },
+  {
+    "ParameterKey": "SecurityGroup",
+    "ParameterValue": "/dev/EcsInstanceSecurityGroup"
+  },
+  {
+    "ParameterKey": "PrivateSubnets",
+    "ParameterValue": "/dev/PrivateSubnets"
+  },
+  {
+    "ParameterKey": "VPC",
+    "ParameterValue": "/dev/VPC"
+  },
+  {
+    "ParameterKey": "EnvironmentKmsKey",
+    "ParameterValue": "/dev/EnvironmentKmsKey"
+  },
+  {
+    "ParameterKey": "EcsCluster",
+    "ParameterValue": "/dev/EcsCluster"
+  },
+  {
+    "ParameterKey": "LoadBalancerListener",
+    "ParameterValue": "/dev/LoadBalancerHttpsListener"
+  },
+  {
+    "ParameterKey": "EfsFileSystemId",
+    "ParameterValue": "/dev/EfsFileSystemId"
+  },
+  {
+    "ParameterKey": "PublicHostedZoneId",
+    "ParameterValue": "/dev/PublicHostedZoneId"
+  },
+  {
+    "ParameterKey": "PublicHostedZoneName",
+    "ParameterValue": "/dev/PublicHostedZoneName"
+  },
+  {
+    "ParameterKey": "LoadBalancerDnsName",
+    "ParameterValue": "/dev/LoadBalancerDnsName"
+  },
+  {
+    "ParameterKey": "LoadBalancerHostedZoneId",
+    "ParameterValue": "/dev/LoadBalancerHostedZoneId"
+  },
+  {
+    "ParameterKey": "RestrictedCIDRs",
+    "ParameterValue": "notapplicable"
+  },
+  {
+    "ParameterKey": "PathPattern",
+    "ParameterValue": "notapplicable"
+  }
+]

--- a/cloudformation/lif-learner-data-export-api-taskdef-includes.yml
+++ b/cloudformation/lif-learner-data-export-api-taskdef-includes.yml
@@ -1,0 +1,20 @@
+Environment:
+  - Name: LIF_MDR_API_URL
+    Value:
+      Fn::Sub: "https://mdr-api.${PublicHostedZoneName}"
+  - Name: OPENAPI_DATA_MODEL_ID
+    Value: "17"
+  - Name: OPENAPI_JSON_FILENAME
+    Value: "openapi_constrained_with_interactions.json"
+  - Name: USE_OPENAPI_DATA_MODEL_FROM_FILE
+    Value: "false"
+  - Name: LIF_QUERY_PLANNER_URL
+    Value:
+      Fn::Sub: "http://query-planner-org1.lif.${EnvironmentName}.aws:8002"
+  - Name: LIF_TRANSLATOR_BASE_URL
+    Value:
+      Fn::Sub: "http://translator-org1.lif.${EnvironmentName}.aws:8007"
+Secrets:
+  - Name: LIF_MDR_API_AUTH_TOKEN
+    ValueFrom:
+      Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/${ServiceName}/MdrApiKey"

--- a/cloudformation/lif-mdr-api-taskdef-includes.yml
+++ b/cloudformation/lif-mdr-api-taskdef-includes.yml
@@ -51,6 +51,9 @@ Secrets:
   - Name: MDR__AUTH__SERVICE_API_KEY__TRANSLATOR
     ValueFrom:
       Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/${ServiceName}/MdrAuthServiceApiKeyTranslator"
+  - Name: MDR__AUTH__SERVICE_API_KEY__LEARNER_DATA_EXPORT
+    ValueFrom:
+      Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/${ServiceName}/MdrAuthServiceApiKeyLearnerDataExport"
   - Name: MDR__AUTH__SERVICE_API_KEY__POST_CONFIRM
     ValueFrom:
       Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${EnvironmentName}/${ServiceName}/MdrAuthServiceApiKeyPostConfirm"

--- a/cloudformation/repositories.yml
+++ b/cloudformation/repositories.yml
@@ -36,6 +36,13 @@ Resources:
       ImageScanningConfiguration:
         ScanOnPush: true
 
+  LearnerDataExportApiRepo:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Sub lif/${EnvironmentName}/lif_learner_data_export_api
+      ImageScanningConfiguration:
+        ScanOnPush: true
+
   QueryCacheApiRepo:
     Type: AWS::ECR::Repository
     Properties:

--- a/demo.aws
+++ b/demo.aws
@@ -44,6 +44,9 @@ STACKS['demo-lif-mdr-cognito']='cognito-selfserve'
 STACKS['demo-lif-mdr-frontend']='s3-hosted-stackset'
 STACKS['demo-lif-mdr-api']='service'
 
+# Learner Data Export (externally accessible; depends on MDR + query-planner-org1 + translator-org1)
+STACKS['demo-lif-learner-data-export-api']='service'
+
 # Dagster OSE
 STACKS['demo-lif-dagster-code-location']='service'
 STACKS['demo-lif-dagster-webserver']='service'
@@ -88,6 +91,7 @@ STACK_ORDER=(
   demo-lif-mdr-cognito
   demo-lif-mdr-frontend
   demo-lif-mdr-api
+  demo-lif-learner-data-export-api
 
   # Dagster OSE
   demo-lif-dagster-code-location

--- a/dev.aws
+++ b/dev.aws
@@ -47,6 +47,9 @@ STACKS['dev-lif-mdr-cognito']='cognito-selfserve'
 STACKS['dev-lif-mdr-frontend']='s3-hosted-stackset'
 STACKS['dev-lif-mdr-api']='service'
 
+# Learner Data Export (externally accessible; depends on MDR + query-planner-org1 + translator-org1)
+STACKS['dev-lif-learner-data-export-api']='service'
+
 # Dagster OSE
 STACKS['dev-lif-dagster-code-location']='service'
 STACKS['dev-lif-dagster-webserver']='service'
@@ -94,6 +97,7 @@ STACK_ORDER=(
   dev-lif-mdr-cognito
   dev-lif-mdr-frontend
   dev-lif-mdr-api
+  dev-lif-learner-data-export-api
 
   # Dagster OSE
   dev-lif-dagster-code-location

--- a/scripts/setup-mdr-api-keys.sh
+++ b/scripts/setup-mdr-api-keys.sh
@@ -188,6 +188,14 @@ main() {
         "/${ENV_NAME}/mdr-api/MdrAuthServiceApiKeyTranslator" \
         "/${ENV_NAME}/translator-org1/MdrApiKey"
 
+    # Learner Data Export key (issue #997/#998). Server-side under /mdr-api/
+    # matches the MDR API task def ValueFrom; client-side under
+    # /learner-data-export-api/ is what the LDE task reads as LIF_MDR_API_AUTH_TOKEN.
+    setup_key_group \
+        "Learner Data Export service key" \
+        "/${ENV_NAME}/mdr-api/MdrAuthServiceApiKeyLearnerDataExport" \
+        "/${ENV_NAME}/learner-data-export-api/MdrApiKey"
+
     # Post-confirmation Lambda key (issue #883 PR 4b). Server-side entry is
     # under /mdr-api/ to match the MDR API task def ValueFrom path; client-side
     # key lives under /mdr-post-confirm/ where the Lambda's IAM policy reads it.


### PR DESCRIPTION
##### Description of Change

Adds CI/CD and AWS deploy configuration for the **Learner Data Export (LDE)** microservice so it can be built and deployed like the other services. The service base/project already landed via #920/#958; this is the deploy plumbing (issue #997, first of the LDE rollout track under #906).

Because LDE is **externally accessible** (open to the external web), it mirrors the *public-facing* service pattern (advisor-api / mdr-api) rather than the internal CloudMap-only pattern (translator):

- `.github/workflows/lif_learner_data_export_api.yml` — builds + pushes the image and updates the ECS service on push-to-main (paths-filtered to the LDE base/project + its component deps) or manual `workflow_dispatch`. Single org1 service.
- `cloudformation/{dev,demo}-lif-learner-data-export-api.params` — `UseLbForService=true`, `DomainNames=lde.{env}.lif.unicon.net`, ALB listener **Priority 3** (next free; 2/4/5/6/7/8 taken), `ContainerPort=8013`, health `/health`.
- `cloudformation/lif-learner-data-export-api-taskdef-includes.yml` — env for the three downstream deps (`LIF_MDR_API_URL`, `LIF_QUERY_PLANNER_URL`, `LIF_TRANSLATOR_BASE_URL`, `OPENAPI_DATA_MODEL_ID=17`) + the `MdrApiKey` SSM secret.
- `dev.aws` / `demo.aws` — register the stack (ordered after `mdr-api`, since LDE depends on MDR + query-planner-org1 + translator-org1).

**Side effects / limitations (intentionally deferred to follow-up issues):**
- This adds *config only* — it does not deploy. Actual dev deploy + external-access verification is #998; demo is #999.
- **SSM params not yet created**: `/{env}/learner-data-export-api/MdrApiKey` must be created before the first deploy (#998).
- **demo `ImageUrl` is `:latest`** as a placeholder; `scripts/release-demo.sh` pins it on first promotion.
- **Auth**: LDE is externally exposed but guarded by the static service API key for now; expanding past that is #1000.
- Query-Planner / Translator may require inbound auth from LDE at deploy time — to be confirmed during #998 integration.

##### How to test
Config-only PR; CI lint applies. Real validation happens at deploy time (#998). Sanity: JSON params parse, workflow + taskdef-includes YAML parse, ALB priority unique, brick paths cover the LDE base's imports.

##### Related Issues

Closes #997
Part of #906 (LDE rollout). Follow-ups: #998 (deploy dev), #999 (deploy demo), #1000 (expand auth).

##### Type of Change

- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates
- [x] CI/CD (`.github/workflows/`)

##### Checklist

- [x] commit message follows commit guidelines
- [ ] tests are included (n/a — deploy config only)
