### PR TITLE
Issue #668: fix MDR import_datamodel reference and constraint handling

### DIFF
--- a/components/lif/mdr_services/import_export_service.py
+++ b/components/lif/mdr_services/import_export_service.py
@@ -281,6 +281,14 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
                 ElementId=element_id,
             )
             await create_data_model_constraint(session=session, data=constraint_dto)
+        else:
+            # Don't drop a constraint silently — a malformed/incomplete export (element name not
+            # found among the imported attributes/entities/value sets) should be visible.
+            logger.warning(
+                "Skipping constraint: %s element %r not found in the imported model",
+                constraint.ElementType,
+                constraint.ElementName,
+            )
 
     return {"ok": True}
 

--- a/components/lif/mdr_services/import_export_service.py
+++ b/components/lif/mdr_services/import_export_service.py
@@ -261,6 +261,7 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
         created_association = await create_entity_association(session=session, data=entity_association_dto)
 
     # Creating constraints
+    skipped_constraints: list[dict] = []
     for constraint in data.DataModelConstraints:
         if constraint.ElementType == DatamodelElementType.Attribute:
             element_id = attribute_name_id.get(constraint.ElementName)
@@ -271,7 +272,8 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
         else:
             element_id = None
 
-        if element_id:
+        # `is not None`, not truthiness: a resolved ElementId of 0 is a valid id, not "not found".
+        if element_id is not None:
             # ElementName is the portable (name-based) reference; the create DTO wants the
             # resolved DB ElementId. ForDataModelId from the export is a source-DB artifact, so
             # remap it to the model we just created.
@@ -283,14 +285,18 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
             await create_data_model_constraint(session=session, data=constraint_dto)
         else:
             # Don't drop a constraint silently — a malformed/incomplete export (element name not
-            # found among the imported attributes/entities/value sets) should be visible.
+            # found among the imported attributes/entities/value sets) should be visible, both in
+            # the logs and in the response so the caller knows what didn't come across.
             logger.warning(
                 "Skipping constraint: %s element %r not found in the imported model",
                 constraint.ElementType,
                 constraint.ElementName,
             )
+            skipped_constraints.append(
+                {"element_type": str(constraint.ElementType), "element_name": constraint.ElementName}
+            )
 
-    return {"ok": True}
+    return {"ok": True, "skipped_constraints": skipped_constraints}
 
 
 async def clone_datamodel(session: AsyncSession, data: CreateCloneDTO):

--- a/components/lif/mdr_services/import_export_service.py
+++ b/components/lif/mdr_services/import_export_service.py
@@ -29,7 +29,10 @@ from lif.mdr_dto.import_export_dto import (
 from lif.mdr_dto.value_set_values_dto import CreateValuesWithValueSetDTO
 from lif.mdr_dto.valueset_dto import CreateValueSetDTO, CreateValueSetWithValuesDTO
 from lif.mdr_services.attribute_service import create_attribute, get_list_of_attributes_for_data_model
-from lif.mdr_services.datamodel_constraints_service import get_data_model_constraints_by_data_model_id
+from lif.mdr_services.datamodel_constraints_service import (
+    create_data_model_constraint,
+    get_data_model_constraints_by_data_model_id,
+)
 from lif.mdr_services.datamodel_service import (
     check_unique_data_model_exists,
     create_datamodel,
@@ -40,7 +43,10 @@ from lif.mdr_services.entity_association_service import (
     create_entity_association,
     get_entity_associations_by_data_model_id,
 )
-from lif.mdr_services.entity_attribute_association_service import get_entity_attribute_associations_by_data_model_id
+from lif.mdr_services.entity_attribute_association_service import (
+    create_entity_attribute_association,
+    get_entity_attribute_associations_by_data_model_id,
+)
 from lif.mdr_services.entity_service import create_entity, get_list_of_entities_for_data_model
 from lif.mdr_services.transformation_service import get_transformations_by_data_model_id
 from lif.mdr_services.value_set_values_service import get_list_of_values_for_value_set
@@ -232,7 +238,7 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
             value_set_id = None
         attribute_dto = CreateAttributeDTO(**attribute.dict(), ValueSetId=value_set_id)
         created_attribute = await create_attribute(session=session, data=attribute_dto)
-        attribute_name_id[attribute.Name] = create_attribute.Id
+        attribute_name_id[attribute.Name] = created_attribute.Id
         if attribute.EntityName:
             entity_id = entity_name_id[attribute.EntityName]
             association = CreateEntityAttributeAssociationDTO(
@@ -241,10 +247,7 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
                 Contributor=attribute.Contributor,
                 ContributorOrganization=attribute.ContributorOrganization,
             )
-            # TODO: this will throw an error. https://linear.app/lif/issue/LIF-578/mdr-api-import-service-method-not-found
-            create_entity_attribute_association = await create_entity_attribute_association(  # noqa: F821
-                session=session, data=association
-            )
+            await create_entity_attribute_association(session=session, data=association)
 
     # Create Entity Association
     for entity_association in data.EntityAssociation:
@@ -260,16 +263,24 @@ async def import_datamodel(session: AsyncSession, data: ImportDataModelDTO):
     # Creating constraints
     for constraint in data.DataModelConstraints:
         if constraint.ElementType == DatamodelElementType.Attribute:
-            element_id = attribute_name_id[constraint.ElementName]
-        if constraint.ElementType == DatamodelElementType.Entity:
-            element_id = entity_name_id[constraint.ElementName]
-        if constraint.ElementType == DatamodelElementType.ValueSet:
-            element_id = value_set_name_id[constraint.ElementName]
+            element_id = attribute_name_id.get(constraint.ElementName)
+        elif constraint.ElementType == DatamodelElementType.Entity:
+            element_id = entity_name_id.get(constraint.ElementName)
+        elif constraint.ElementType == DatamodelElementType.ValueSet:
+            element_id = value_set_name_id.get(constraint.ElementName)
         else:
             element_id = None
 
         if element_id:
-            constraint_dto = CreateDataModelConstraintsDTO(**constraint.dict(), ElementId=element_id)
+            # ElementName is the portable (name-based) reference; the create DTO wants the
+            # resolved DB ElementId. ForDataModelId from the export is a source-DB artifact, so
+            # remap it to the model we just created.
+            constraint_dto = CreateDataModelConstraintsDTO(
+                **constraint.dict(exclude={"ElementName", "ForDataModelId"}),
+                ForDataModelId=data_model.Id,
+                ElementId=element_id,
+            )
+            await create_data_model_constraint(session=session, data=constraint_dto)
 
     return {"ok": True}
 

--- a/components/lif/mdr_services/schema_upload_service.py
+++ b/components/lif/mdr_services/schema_upload_service.py
@@ -73,6 +73,19 @@ async def create_reference_associations_for_children(
 ):
     entity_properties = entity_md.get("properties", {})
     for prop_name, prop in entity_properties.items():
+        # KNOWN BUG (#756): this only detects genuine OpenAPI "$ref" properties, but MDR's own
+        # schema generator (schema_generation_service.add_ref) INLINES references rather than
+        # emitting "$ref", and marks them with a "Ref" infix in the property key
+        # ("Ref<Child>" / "<relationship>Ref<Child>", see schema_generation_service.py:802-805).
+        # So re-uploading an MDR-exported schema silently drops every reference here.
+        #
+        # Tactical fix: also treat a "Ref"-keyed inlined object as a reference (the inlined object
+        # IS the referenced schema, so read its UniqueName/DataModelId directly) and parse the
+        # relationship as prop_name.split("Ref", 1)[0].
+        # Preferred fix (more robust, two-sided): have the generator stamp an explicit marker on
+        # the inlined object on export — e.g. "x-reference-to": "<UniqueName>" — and key off that
+        # here instead of string-sniffing "Ref" out of property names (which mis-parses any entity
+        # legitimately named with "Ref" in it).
         if "$ref" in prop:  # This is a reference to another entity
             ref_path = prop[
                 "$ref"

--- a/test/components/lif/mdr_services/test_import_export_service.py
+++ b/test/components/lif/mdr_services/test_import_export_service.py
@@ -1,19 +1,14 @@
 """Regression tests for import_datamodel (Issue #668).
 
-These exercise the real import_datamodel logic end-to-end with the I/O service
-calls mocked out, guarding the three bugs fixed alongside #668:
-
-1. attribute name->id map used the `create_attribute` function object instead of
-   the created row (`created_attribute.Id`), corrupting later reference resolution.
-2. `create_entity_attribute_association` was never imported, so any attribute with
-   an EntityName raised NameError mid-import (the #668 report).
-3. the constraints loop clobbered Attribute/Entity element ids to None via a stray
-   `else`, never persisted the built DTO, and forwarded the source-DB ForDataModelId.
+These exercise the real import_datamodel logic end-to-end with the create_* I/O
+calls mocked out. Each test guards a specific #668 regression — see the docstring
+on each test rather than a running list here (which would drift as tests are added).
 """
 
 import types
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
 
 from lif.datatypes.mdr_sql_model import DataModelType, DatamodelElementType
 from lif.mdr_dto.datamodel_dto import CreateDataModelDTO
@@ -24,9 +19,9 @@ from lif.mdr_dto.import_export_dto import (
     ImportEntityDTO,
 )
 
-pytestmark = pytest.mark.asyncio
-
-svc = pytest.importorskip("lif.mdr_services.import_export_service")
+# Hard import (not importorskip): the premise of this suite is that the module used
+# to blow up at import/call time, so a future import regression must FAIL, not skip.
+from lif.mdr_services import import_export_service as svc
 
 NEW_DATA_MODEL_ID = 42
 ENTITY_ID = 100
@@ -71,6 +66,9 @@ def _import_payload():
 
 
 async def test_import_creates_entity_attribute_association_with_resolved_ids(patched_services):
+    """Guards #668 bugs 1 & 2: the attribute name->id map used the create_attribute
+    function object instead of created_attribute.Id, and create_entity_attribute_association
+    was never imported (NameError mid-import for any attribute with an EntityName)."""
     # Before the fix this raised (NameError on the unimported function / AttributeError on the
     # function object's .Id) before ever reaching this assertion.
     await svc.import_datamodel(session=AsyncMock(), data=_import_payload())
@@ -83,6 +81,8 @@ async def test_import_creates_entity_attribute_association_with_resolved_ids(pat
 
 
 async def test_import_persists_constraint_with_remapped_ids(patched_services):
+    """Guards #668 bug 3: the constraints loop clobbered element ids to None, never
+    persisted the built DTO, and forwarded the source-DB ForDataModelId."""
     await svc.import_datamodel(session=AsyncMock(), data=_import_payload())
 
     create_constraint = patched_services["create_data_model_constraint"]
@@ -94,8 +94,8 @@ async def test_import_persists_constraint_with_remapped_ids(patched_services):
 
 
 async def test_import_skips_constraint_with_unresolvable_element(patched_services):
-    # A constraint whose ElementName isn't among the imported elements must be skipped
-    # (logged, not persisted) rather than crashing or silently being lost.
+    """An unresolvable constraint element is skipped (logged + reported in the
+    response), not crashed or silently dropped (#668)."""
     payload = ImportDataModelDTO(
         DataModel=CreateDataModelDTO(Name="TestDM", Type=DataModelType.SourceSchema, DataModelVersion="1.0"),
         Entities=[ImportEntityDTO(Name="Person", UniqueName="Person")],
@@ -113,6 +113,10 @@ async def test_import_skips_constraint_with_unresolvable_element(patched_service
         ],
     )
 
-    await svc.import_datamodel(session=AsyncMock(), data=payload)
+    result = await svc.import_datamodel(session=AsyncMock(), data=payload)
 
     patched_services["create_data_model_constraint"].assert_not_awaited()
+    # the skip is reported back to the caller, not just logged (cbeach47 review)
+    assert result["skipped_constraints"] == [
+        {"element_type": str(DatamodelElementType.Entity), "element_name": "NoSuchEntity"}
+    ]

--- a/test/components/lif/mdr_services/test_import_export_service.py
+++ b/test/components/lif/mdr_services/test_import_export_service.py
@@ -91,3 +91,28 @@ async def test_import_persists_constraint_with_remapped_ids(patched_services):
     assert constraint.ElementType == DatamodelElementType.Entity
     assert constraint.ElementId == ENTITY_ID  # name resolved against the freshly created entity
     assert constraint.ForDataModelId == NEW_DATA_MODEL_ID  # remapped off the source-DB artifact (999)
+
+
+async def test_import_skips_constraint_with_unresolvable_element(patched_services):
+    # A constraint whose ElementName isn't among the imported elements must be skipped
+    # (logged, not persisted) rather than crashing or silently being lost.
+    payload = ImportDataModelDTO(
+        DataModel=CreateDataModelDTO(Name="TestDM", Type=DataModelType.SourceSchema, DataModelVersion="1.0"),
+        Entities=[ImportEntityDTO(Name="Person", UniqueName="Person")],
+        Attributes=[],
+        ValueSets=[],
+        EntityAssociation=[],
+        DataModelConstraints=[
+            ImportDataModelConstraintsDTO(
+                ForDataModelId=SOURCE_DATA_MODEL_ID,
+                ElementType=DatamodelElementType.Entity,
+                ElementName="NoSuchEntity",
+                Contributor="tester",
+                ContributorOrganization="UniconQA",
+            )
+        ],
+    )
+
+    await svc.import_datamodel(session=AsyncMock(), data=payload)
+
+    patched_services["create_data_model_constraint"].assert_not_awaited()

--- a/test/components/lif/mdr_services/test_import_export_service.py
+++ b/test/components/lif/mdr_services/test_import_export_service.py
@@ -1,0 +1,93 @@
+"""Regression tests for import_datamodel (Issue #668).
+
+These exercise the real import_datamodel logic end-to-end with the I/O service
+calls mocked out, guarding the three bugs fixed alongside #668:
+
+1. attribute name->id map used the `create_attribute` function object instead of
+   the created row (`created_attribute.Id`), corrupting later reference resolution.
+2. `create_entity_attribute_association` was never imported, so any attribute with
+   an EntityName raised NameError mid-import (the #668 report).
+3. the constraints loop clobbered Attribute/Entity element ids to None via a stray
+   `else`, never persisted the built DTO, and forwarded the source-DB ForDataModelId.
+"""
+
+import types
+import pytest
+from unittest.mock import AsyncMock
+
+from lif.datatypes.mdr_sql_model import DataModelType, DatamodelElementType
+from lif.mdr_dto.datamodel_dto import CreateDataModelDTO
+from lif.mdr_dto.import_export_dto import (
+    ImportAttributeDTO,
+    ImportDataModelConstraintsDTO,
+    ImportDataModelDTO,
+    ImportEntityDTO,
+)
+
+pytestmark = pytest.mark.asyncio
+
+svc = pytest.importorskip("lif.mdr_services.import_export_service")
+
+NEW_DATA_MODEL_ID = 42
+ENTITY_ID = 100
+ATTRIBUTE_ID = 200
+SOURCE_DATA_MODEL_ID = 999  # the exporting install's id — a DB artifact that must be remapped
+
+
+@pytest.fixture
+def patched_services(monkeypatch):
+    """Replace every create_* call import_datamodel makes with an AsyncMock."""
+    mocks = {
+        "create_datamodel": AsyncMock(return_value=types.SimpleNamespace(Id=NEW_DATA_MODEL_ID)),
+        "create_entity": AsyncMock(return_value=types.SimpleNamespace(Id=ENTITY_ID)),
+        "create_attribute": AsyncMock(return_value=types.SimpleNamespace(Id=ATTRIBUTE_ID)),
+        "create_entity_attribute_association": AsyncMock(),
+        "create_entity_association": AsyncMock(),
+        "create_value_set_with_values": AsyncMock(),
+        "create_data_model_constraint": AsyncMock(),
+    }
+    for name, mock in mocks.items():
+        monkeypatch.setattr(svc, name, mock)
+    return mocks
+
+
+def _import_payload():
+    return ImportDataModelDTO(
+        DataModel=CreateDataModelDTO(Name="TestDM", Type=DataModelType.SourceSchema, DataModelVersion="1.0"),
+        Entities=[ImportEntityDTO(Name="Person", UniqueName="Person")],
+        Attributes=[ImportAttributeDTO(Name="firstName", DataType="string", EntityName="Person")],
+        ValueSets=[],
+        EntityAssociation=[],
+        DataModelConstraints=[
+            ImportDataModelConstraintsDTO(
+                ForDataModelId=SOURCE_DATA_MODEL_ID,
+                ElementType=DatamodelElementType.Entity,
+                ElementName="Person",
+                Contributor="tester",
+                ContributorOrganization="UniconQA",
+            )
+        ],
+    )
+
+
+async def test_import_creates_entity_attribute_association_with_resolved_ids(patched_services):
+    # Before the fix this raised (NameError on the unimported function / AttributeError on the
+    # function object's .Id) before ever reaching this assertion.
+    await svc.import_datamodel(session=AsyncMock(), data=_import_payload())
+
+    eaa = patched_services["create_entity_attribute_association"]
+    eaa.assert_awaited_once()
+    association = eaa.await_args.kwargs["data"]
+    assert association.EntityId == ENTITY_ID  # resolved from entity_name_id map
+    assert association.AttributeId == ATTRIBUTE_ID  # created_attribute.Id, not the function object
+
+
+async def test_import_persists_constraint_with_remapped_ids(patched_services):
+    await svc.import_datamodel(session=AsyncMock(), data=_import_payload())
+
+    create_constraint = patched_services["create_data_model_constraint"]
+    create_constraint.assert_awaited_once()  # was never called before (clobbered to None + not persisted)
+    constraint = create_constraint.await_args.kwargs["data"]
+    assert constraint.ElementType == DatamodelElementType.Entity
+    assert constraint.ElementId == ENTITY_ID  # name resolved against the freshly created entity
+    assert constraint.ForDataModelId == NEW_DATA_MODEL_ID  # remapped off the source-DB artifact (999)


### PR DESCRIPTION
##### Description of Change

`import_datamodel` (the MDR native export→import path, `POST /import/`) never worked end-to-end. The native import deliberately references entities/attributes/value-sets **by name** rather than by the source DB's primary keys — the right approach for portability between installs (DB ids are artifacts of the exporting install). But the implementation had three coupled bugs that crashed or silently dropped data:

- **#668 (the reported crash):** `create_entity_attribute_association` was called but never imported, so any imported attribute carrying an `EntityName` raised `NameError` mid-import. A `# noqa: F821` only masked the linter. → wired the import and removed the self-shadowing assignment of the call result.
- **Corrupt attribute map:** the name→id map stored `create_attribute.Id` (the function object) instead of `created_attribute.Id` (the created row), corrupting later name-based reference resolution. → use the created row's id.
- **Constraints dropped:** the constraints loop used stray `if`s with a trailing `else` that clobbered `Attribute`/`Entity` element ids back to `None`, then built a DTO that was **never persisted**, and forwarded the source-DB `ForDataModelId` unchanged. → switched to `elif`, remap `ForDataModelId` to the freshly created model, drop the non-field `ElementName` before constructing the create DTO, and actually call `create_data_model_constraint`.

**Side effects / limitations:** No API or schema change. `import_datamodel` still commits per-row, so a mid-import failure can leave a partially-imported model — wrapping the whole import in a single transaction is worth doing but intentionally out of scope here. Transformations (mappings) and entity-attribute associations remain commented out of `ImportDataModelDTO` (dup-name ambiguity) and are tracked separately (#771).

This PR also adds a forward-looking in-code comment for **#756** in `schema_upload_service.py`: the *create-by-upload* path only detects genuine OpenAPI `$ref`, but MDR's own schema generator inlines references and marks them with a `Ref` infix in the property key, so re-uploading an MDR-exported schema silently drops references. The comment records the tactical fix and the preferred `x-reference-to` marker approach so the design isn't lost ahead of the #756 work. No behavior change.

**How to test:** `uv run pytest test/components/lif/mdr_services/test_import_export_service.py` — two regression tests drive `import_datamodel` end-to-end with I/O mocked, asserting the entity-attribute association is created with resolved ids and the constraint is persisted with a remapped `ForDataModelId`. Both fail against the pre-fix code.

##### Related Issues

Closes #668
Refs #756 (documentation only)

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

##### Project Area(s) Affected

- [x] components/
- [x] test/ or e2e/

---

##### Checklist

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] tests are included (unit and/or integration tests)
- [x] code passes linting checks (`uv run ruff check`)
- [x] code passes formatting checks (`uv run ruff format`)
- [x] code passes type checking (`uv run ty check`) — no new diagnostics introduced
- [x] pre-commit hooks have been run successfully

##### Testing

- [x] Automated tests added/updated

##### Additional Notes

The two commits are scoped per issue (`Issue #668:` and `Issue #756:`). The #756 change is a doc-only comment in the same MDR-import subsystem surfaced by the same investigation; happy to split it into its own PR if reviewers prefer strict one-issue separation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
