### PR TITLE
Issue #998: fix LDE ALB listener-rule priority collision (3 → 6)

### DIFF
--- a/cloudformation/demo-lif-learner-data-export-api.params
+++ b/cloudformation/demo-lif-learner-data-export-api.params
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "Priority",
-    "ParameterValue": "3"
+    "ParameterValue": "6"
   },
   {
     "ParameterKey": "EcsLaunchType",

--- a/cloudformation/dev-lif-learner-data-export-api.params
+++ b/cloudformation/dev-lif-learner-data-export-api.params
@@ -25,7 +25,7 @@
   },
   {
     "ParameterKey": "Priority",
-    "ParameterValue": "3"
+    "ParameterValue": "6"
   },
   {
     "ParameterKey": "EcsLaunchType",


### PR DESCRIPTION
##### Description of Change

The `learner-data-export-api` CloudFormation params set the ALB HTTPS **listener-rule `Priority` to `3`**, which is already in use on both the dev and demo shared ALBs by `advisor(.dev|.demo).lif.unicon.net`. The stack create fails with `"Priority '3' is currently in use"` (`HandlerErrorCode: AlreadyExists`) and rolls back (`ROLLBACK_COMPLETE`).

**Fix:** move both dev and demo to **priority 6** — free on both listeners today:

| env | in-use priorities | chosen |
|-----|-------------------|--------|
| dev | 2,3,4,5,8 | **6** |
| demo | 1,2,4,5,8 | **6** |

Listener rules here are host-header based (one hostname per service) and don't overlap, so the priority only needs to be unique on the listener.

**Validation:** with priority 6, the dev stack deployed cleanly (`CREATE_COMPLETE`); the service is healthy (`learner-data-export-api-FARGATE` 1/1, rollout COMPLETED) and externally reachable — `https://lde.dev.lif.unicon.net/health` → `200 {"status":"ok"}` with valid TLS.

##### Related Issues

Part of #998 (deploy LDE to dev). Prevents the same failure on #999 (deploy to demo).

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates

---

##### Checklist

- [x] commit message follows commit guidelines

##### Testing

- [x] Manual testing performed — dev deploy succeeded and `/health` returns 200 externally over HTTPS

##### Additional Notes

Discovered while executing the #998 dev-deploy runbook. The dev stack is already deployed with this priority (deployed from this branch); this PR brings the checked-in config in line and fixes demo ahead of #999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
