### PR TITLE
chore: release-demo 2026-06-23 — pin demo image tags to current dev builds

### DIFF
--- a/cloudformation/demo-lif-advisor-api.params
+++ b/cloudformation/demo-lif-advisor-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_api:2026-05-16-02-30-52-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_api:2026-06-04-02-33-35-e006048"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-advisor-app.params
+++ b/cloudformation/demo-lif-advisor-app.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_app:2026-03-23-19-22-37-15b996d"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_app:2026-06-23-15-54-56-66cd748"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-dagster-code-location.params
+++ b/cloudformation/demo-lif-dagster-code-location.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/dagster_code_location:2026-05-16-02-30-42-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/dagster_code_location:2026-06-19-20-11-30-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org1.params
+++ b/cloudformation/demo-lif-graphql-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org2.params
+++ b/cloudformation/demo-lif-graphql-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org3.params
+++ b/cloudformation/demo-lif-graphql-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql.params
+++ b/cloudformation/demo-lif-graphql.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-05-16-02-30-51-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-mariadb-org1.params
+++ b/cloudformation/demo-lif-identity-mapper-mariadb-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-05-16-02-36-50-893562b"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-06-19-20-11-23-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-mariadb-org2.params
+++ b/cloudformation/demo-lif-identity-mapper-mariadb-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-05-16-02-36-50-893562b"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-06-19-20-11-23-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-mariadb-org3.params
+++ b/cloudformation/demo-lif-identity-mapper-mariadb-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-05-16-02-36-50-893562b"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_mariadb:2026-06-19-20-11-23-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-org1.params
+++ b/cloudformation/demo-lif-identity-mapper-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-05-16-02-30-50-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-org2.params
+++ b/cloudformation/demo-lif-identity-mapper-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-05-16-02-30-50-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-identity-mapper-org3.params
+++ b/cloudformation/demo-lif-identity-mapper-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-05-16-02-30-50-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_identity_mapper_api:2026-06-19-20-11-28-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-learner-data-export-api.params
+++ b/cloudformation/demo-lif-learner-data-export-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:latest"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-06-23-21-36-30-43b2084"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-05-27-17-25-57-2db4ab9"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-06-19-20-11-29-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-orchestrator.params
+++ b/cloudformation/demo-lif-orchestrator.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_orchestrator:2026-05-16-02-30-45-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_orchestrator:2026-06-19-20-11-29-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache-org1.params
+++ b/cloudformation/demo-lif-query-cache-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-06-19-20-11-35-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache-org2.params
+++ b/cloudformation/demo-lif-query-cache-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-06-19-20-11-35-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache-org3.params
+++ b/cloudformation/demo-lif-query-cache-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-06-19-20-11-35-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-cache.params
+++ b/cloudformation/demo-lif-query-cache.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-05-21-02-18-34-cec4abd"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_cache_api:2026-06-19-20-11-35-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner-org1.params
+++ b/cloudformation/demo-lif-query-planner-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-06-19-20-11-30-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner-org2.params
+++ b/cloudformation/demo-lif-query-planner-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-06-19-20-11-30-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner-org3.params
+++ b/cloudformation/demo-lif-query-planner-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-06-19-20-11-30-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-query-planner.params
+++ b/cloudformation/demo-lif-query-planner.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-05-16-02-30-46-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_query_planner_api:2026-06-19-20-11-30-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-semantic-search.params
+++ b/cloudformation/demo-lif-semantic-search.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_semantic_search_mcp_server:2026-05-16-02-31-25-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_semantic_search_mcp_server:2026-06-19-20-13-08-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-translator-org1.params
+++ b/cloudformation/demo-lif-translator-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_translator_api:2026-05-16-02-30-44-ed0a22e"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_translator_api:2026-06-19-20-11-33-0025436"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
##### Description of Change

Promotes the **26 demo service param files** to the images currently running in dev, via `scripts/release-demo.sh --apply` (resolves each repo's dev `:latest` to its pinned version tag). Tag-only changes (26 removed / 26 added; verified no structural edits).

Notable pins:
- most services → `2026-06-19-…-0025436` (dev's 06-19 build)
- `advisor-app` → `2026-06-23-…-66cd748` (the #1003 lockfile fix)
- `learner-data-export-api` → `2026-06-23-…-43b2084` (#1010)
- `graphql-org{1,2,3}` → 06-19 build (note: demo graphql stays down on #1011 regardless — data-driven, fixed by #1012 + redeploy or the MDR rename, not this image bump)

**Deploy:** the 22 real service stacks (∩ `STACK_ORDER`, in order) are being deployed per-stack via `aws-deploy.sh -s demo --only-stack …`. **LDE is excluded** — the demo LDE stack/SSM keys don't exist yet (that's #999). The bare `demo-lif-{graphql,query-cache,query-planner}.params` are shared/template params not in `STACK_ORDER`, so they're updated but not separately deployed.

##### Related Issues

Demo promotion (dev → demo). Refs #999 (LDE-to-demo, deferred), #1011/#1012 (demo graphql still down until fixed).

##### Type of Change

- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates

---

##### Checklist

- [x] commit message follows commit guidelines

##### Additional Notes

Generated by `release-demo.sh`; deploy run separately (per-stack, LDE excluded). MDR frontend (S3/CloudFront) and SAM databases are separate guide steps, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)