### PR TITLE
#906 - logic for available data models endpoint

### DIFF
--- a/bases/lif/learner_data_export_api/learner_data_export_endpoints.py
+++ b/bases/lif/learner_data_export_api/learner_data_export_endpoints.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from lif.datatypes.core import TargetTransformationDataModelDTO, TargetTransformationDataModelsDTO
 from lif.datatypes.mdr_consumer import MdrRetrieveDataModelsDTO
 from lif.lif_schema_config.core import LIFSchemaConfig
-from lif.mdr_client.core import MDRClientException, fetch_data_models_from_mdr
+from lif.mdr_client.core import MDRClientException, fetch_data_models_from_mdr, get_transformation_groups_from_mdr
 from lif.mdr_utils.logger_config import get_logger
 from lif.query_planner_client import QueryPlannerException, fetch_query_from_query_planner
 from lif.translator_client import TranslatorException, translate_learner_data
@@ -146,27 +146,57 @@ async def get_data(
 
 @router.get("/available-data-formats", response_model=TargetTransformationDataModelsDTO)
 async def get_available_data_formats(request: Request):
-    # TODO: Build this out.
-    logger.info("Received request for available data formats as %s", request.state.principal)
+    source_schema_id = CONFIG.openapi_data_model_id
+    if source_schema_id is None:
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="OPENAPI_DATA_MODEL_ID is not configured. Unable to retrieve available data formats",
+        )
+
+    logger.info(
+        "Received request for available data formats as %s, source model id = %s",
+        request.state.principal,
+        source_schema_id,
+    )
+
+    try:
+        transformation_groups_json = await get_transformation_groups_from_mdr(
+            config=CONFIG, source_data_model_id=source_schema_id
+        )
+    except MDRClientException as e:
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Unable to retrieve available data formats"
+        ) from e
+
+    # Each transformation group yields one target data model + the group's version.
+    # Collapse groups that share a target (keyed by target data model id) into a
+    # single data format whose TransformationVersions lists every group version.
+    data_models_by_id: dict[int, TargetTransformationDataModelDTO] = {}
+    for group in transformation_groups_json.get("data", []):
+        target_id = group.get("TargetDataModelId")
+        if target_id is None:
+            continue
+
+        data_model = data_models_by_id.get(target_id)
+        if data_model is None:
+            target = group.get("TargetDataModel") or {}
+            data_model = TargetTransformationDataModelDTO(
+                name=target.get("name") or "",
+                version=target.get("version") or "",
+                contributorOrganization=target.get("contributorOrganization") or "",
+                TransformationVersions=[],
+            )
+            data_models_by_id[target_id] = data_model
+
+        group_version = group.get("GroupVersion")
+        if group_version and group_version not in data_model.TransformationVersions:
+            data_model.TransformationVersions.append(group_version)
+
+    for data_model in data_models_by_id.values():
+        data_model.TransformationVersions.sort()
 
     data_formats = TargetTransformationDataModelsDTO(
-        metadata={"total": 3},
-        DataFormats=[
-            TargetTransformationDataModelDTO(
-                name="OpenBadges 3.0",
-                version="1.0.3",
-                contributorOrganization="OB",
-                TransformationVersions=["1.0.0", "1.1.0"],
-            ),
-            TargetTransformationDataModelDTO(
-                name="CEDS", version="2.0.0", contributorOrganization="CEDS Org", TransformationVersions=["2.0.0"]
-            ),
-            TargetTransformationDataModelDTO(
-                name="ExampleDataSource",
-                version="1.0.1",
-                contributorOrganization="Community",
-                TransformationVersions=["1.3.0"],
-            ),
-        ],
+        metadata={"total": len(data_models_by_id)},
+        DataFormats=sorted(data_models_by_id.values(), key=lambda dm: dm.name),
     )
     return data_formats

--- a/bases/lif/learner_data_export_api/learner_data_export_endpoints.py
+++ b/bases/lif/learner_data_export_api/learner_data_export_endpoints.py
@@ -144,6 +144,13 @@ async def get_data(
     return translated_data
 
 
+def _version_sort_key(version: str) -> list[tuple[int, object]]:
+    # Sort dotted versions numerically (so "1.9.0" < "1.10.0"), falling back to
+    # lexical ordering for non-numeric segments. Each segment is tagged so numeric
+    # and non-numeric parts never compare against each other.
+    return [(0, int(part)) if part.isdigit() else (1, part) for part in version.split(".")]
+
+
 @router.get("/available-data-formats", response_model=TargetTransformationDataModelsDTO)
 async def get_available_data_formats(request: Request):
     source_schema_id = CONFIG.openapi_data_model_id
@@ -193,7 +200,7 @@ async def get_available_data_formats(request: Request):
             data_model.TransformationVersions.append(group_version)
 
     for data_model in data_models_by_id.values():
-        data_model.TransformationVersions.sort()
+        data_model.TransformationVersions.sort(key=_version_sort_key)
 
     data_formats = TargetTransformationDataModelsDTO(
         metadata={"total": len(data_models_by_id)},

--- a/bases/lif/mdr_restapi/transformation_endpoint.py
+++ b/bases/lif/mdr_restapi/transformation_endpoint.py
@@ -194,6 +194,7 @@ async def get_all_transformation_groups(
     size: int = Query(10, ge=1),  # Default to size 10
     session: AsyncSession = Depends(get_session),
     pagination: bool = True,
+    exportable: bool = False,
 ):
     # Calculate offset for pagination
     offset = (page - 1) * size
@@ -205,6 +206,7 @@ async def get_all_transformation_groups(
         source_data_model_id=source_data_model_id,
         target_data_model_id=target_data_model_id,
         pagination=pagination,
+        exportable=exportable,
     )
 
     if pagination:

--- a/components/lif/mdr_client/__init__.py
+++ b/components/lif/mdr_client/__init__.py
@@ -1,24 +1,23 @@
 from lif.mdr_client.core import (
-    # Config-based functions (preferred)
-    load_openapi_schema,
-    fetch_schema_from_mdr,
-    # File loading
-    get_openapi_lif_data_model_from_file,
-    # Legacy env-var based functions
-    get_openapi_lif_data_model,
-    get_openapi_lif_data_model_sync,
-    get_data_model_schema,
-    get_data_model_schema_sync,
-    get_data_model_transformation,
     # Exceptions
     MDRClientException,
     MDRConfigurationError,
+    fetch_schema_from_mdr,
+    get_data_model_schema,
+    get_data_model_schema_sync,
+    get_data_model_transformation,
+    get_openapi_lif_data_model,
+    get_openapi_lif_data_model_from_file,
+    get_openapi_lif_data_model_sync,
+    get_transformation_groups_from_mdr,
+    load_openapi_schema,
 )
 
 __all__ = [
     # Config-based functions (preferred)
     "load_openapi_schema",
     "fetch_schema_from_mdr",
+    "get_transformation_groups_from_mdr",
     # File loading
     "get_openapi_lif_data_model_from_file",
     # Legacy env-var based functions

--- a/components/lif/mdr_client/core.py
+++ b/components/lif/mdr_client/core.py
@@ -264,6 +264,22 @@ def fetch_data_models_from_mdr(
         raise MDRClientException(msg)
 
 
+async def get_transformation_groups_from_mdr(*, config: "LIFSchemaConfig", source_data_model_id: str) -> dict:
+    url: str = f"{config.mdr_api_url}/transformation_groups/?exportable=True&pagination=False&size=100&source_data_model_id={source_data_model_id}"
+    logger.info("Calling the MDR URL: %s with a timeout of %s", url, _get_mdr_timeout_seconds())
+    try:
+        async for client in _get_mdr_client():
+            response = await client.get(url, headers=_build_mdr_headers())
+        response.raise_for_status()
+        response_json = response.json()
+        logger.info(f"Number of transformation group versions for the source model from MDR: {response_json['total']}")
+        return response_json
+    except Exception as e:
+        msg = "MDR Client error"
+        logger.exception(msg)
+        raise MDRClientException(msg) from e
+
+
 # =============================================================================
 # Legacy sync functions (kept for backward compatibility)
 # =============================================================================

--- a/components/lif/mdr_client/core.py
+++ b/components/lif/mdr_client/core.py
@@ -265,18 +265,55 @@ def fetch_data_models_from_mdr(
 
 
 async def get_transformation_groups_from_mdr(*, config: "LIFSchemaConfig", source_data_model_id: str) -> dict:
-    url: str = f"{config.mdr_api_url}/transformation_groups/?exportable=True&pagination=False&size=100&source_data_model_id={source_data_model_id}"
-    logger.info("Calling the MDR URL: %s with a timeout of %s", url, _get_mdr_timeout_seconds())
+    """
+    Fetch the (exportable) transformation groups for a source data model from MDR.
+
+    Args:
+        config: LIFSchemaConfig instance with MDR settings
+        source_data_model_id: The ID of the source data model whose groups to fetch
+
+    Returns:
+        The MDR listing response as JSON ({"total": int, "data": [...]})
+
+    Raises:
+        MDRClientException: If MDR is unavailable or returns an error
+    """
+    url = f"{config.mdr_api_url}/transformation_groups/"
+    params: dict[str, str | bool | int] = {
+        "source_data_model_id": source_data_model_id,
+        "exportable": True,
+        "pagination": False,
+        "size": 100,
+    }
+    headers = _build_mdr_headers(config.mdr_api_auth_token)
+
+    logger.info("Fetching transformation groups from MDR: %s params=%s", url, params)
+
     try:
         async for client in _get_mdr_client():
-            response = await client.get(url, headers=_build_mdr_headers())
+            response = await client.get(url, headers=headers, params=params)
         response.raise_for_status()
         response_json = response.json()
-        logger.info(f"Number of transformation group versions for the source model from MDR: {response_json['total']}")
+        logger.info("Number of transformation group versions for the source model from MDR: %s", response_json["total"])
         return response_json
+
+    except httpx.TimeoutException as e:
+        msg = f"MDR request timed out: {e}"
+        logger.error(msg)
+        raise MDRClientException(msg) from e
+
+    except httpx.ConnectError as e:
+        msg = f"Failed to connect to MDR at {config.mdr_api_url}: {e}"
+        logger.error(msg)
+        raise MDRClientException(msg) from e
+
+    except httpx.HTTPStatusError as e:
+        logger.error(f"MDR HTTP error: {e.response.status_code} - {e.response.text}")
+        raise MDRClientException(f"MDR returned HTTP {e.response.status_code}") from e
+
     except Exception as e:
-        msg = "MDR Client error"
-        logger.exception(msg)
+        msg = f"Unexpected error fetching transformation groups from MDR: {e}"
+        logger.error(msg)
         raise MDRClientException(msg) from e
 
 

--- a/components/lif/mdr_dto/transformation_group_dto.py
+++ b/components/lif/mdr_dto/transformation_group_dto.py
@@ -22,7 +22,7 @@ class TransformationGroupDTO(BaseModel):
     SourceDataModel: Optional[DataModelRefDTO] = None
     TargetDataModel: Optional[DataModelRefDTO] = None
     Name: Optional[str] = None
-    GroupVersion: str
+    GroupVersion: Optional[str] = None
     Description: Optional[str] = None
     Notes: Optional[str] = None
     CreationDate: Optional[datetime] = None  # New column

--- a/components/lif/mdr_dto/transformation_group_dto.py
+++ b/components/lif/mdr_dto/transformation_group_dto.py
@@ -1,8 +1,15 @@
-from pydantic import BaseModel
-from typing import List, Optional
 from datetime import datetime
+from typing import List, Optional
 
 from lif.mdr_dto.transformation_dto import CreateTransformationDTO, TransformationDTO, UpdateTransformationDTO
+from pydantic import BaseModel
+
+
+class DataModelRefDTO(BaseModel):
+    # Data-portable identity of a data model, independent of its primary key.
+    name: str
+    version: Optional[str] = None
+    contributorOrganization: Optional[str] = None
 
 
 class TransformationGroupDTO(BaseModel):
@@ -11,8 +18,11 @@ class TransformationGroupDTO(BaseModel):
     TargetDataModelId: int
     SourceDataModelName: Optional[str] = None
     TargetDataModelName: Optional[str] = None
+    # Populated only when exportable=True: portable (name, version, org) refs.
+    SourceDataModel: Optional[DataModelRefDTO] = None
+    TargetDataModel: Optional[DataModelRefDTO] = None
     Name: Optional[str] = None
-    GroupVersion: str = None
+    GroupVersion: str
     Description: Optional[str] = None
     Notes: Optional[str] = None
     CreationDate: Optional[datetime] = None  # New column

--- a/components/lif/mdr_services/transformation_service.py
+++ b/components/lif/mdr_services/transformation_service.py
@@ -1018,7 +1018,7 @@ async def get_paginated_transformations_groups(
         transformation_group_dto.SourceDataModelName = source_data_model.Name
         transformation_group_dto.TargetDataModelName = target_data_model.Name
         if exportable:
-            # Add non-portable IDs with (name, version, org) refs for export.
+            # Add portable (name, version, org) refs alongside the non-portable IDs.
             transformation_group_dto.SourceDataModel = DataModelRefDTO(
                 name=source_data_model.Name,
                 version=source_data_model.DataModelVersion,

--- a/components/lif/mdr_services/transformation_service.py
+++ b/components/lif/mdr_services/transformation_service.py
@@ -22,6 +22,7 @@ from lif.mdr_dto.transformation_dto import (
 )
 from lif.mdr_dto.transformation_group_dto import (
     CreateTransformationGroupDTO,
+    DataModelRefDTO,
     TransformationGroupDTO,
     UpdateTransformationGroupDTO,
 )
@@ -964,6 +965,7 @@ async def get_paginated_transformations_groups(
     pagination: bool = True,
     source_data_model_id: int = None,
     target_data_model_id: int = None,
+    exportable: bool = False,
 ):
     transformations_group_dtos: list[TransformationGroupDTO] = []
     # Query to count total transformations for pagination
@@ -1015,6 +1017,18 @@ async def get_paginated_transformations_groups(
         target_data_model = await check_datamodel_by_id(session=session, id=transformation_group_dto.TargetDataModelId)
         transformation_group_dto.SourceDataModelName = source_data_model.Name
         transformation_group_dto.TargetDataModelName = target_data_model.Name
+        if exportable:
+            # Add non-portable IDs with (name, version, org) refs for export.
+            transformation_group_dto.SourceDataModel = DataModelRefDTO(
+                name=source_data_model.Name,
+                version=source_data_model.DataModelVersion,
+                contributorOrganization=source_data_model.ContributorOrganization,
+            )
+            transformation_group_dto.TargetDataModel = DataModelRefDTO(
+                name=target_data_model.Name,
+                version=target_data_model.DataModelVersion,
+                contributorOrganization=target_data_model.ContributorOrganization,
+            )
         transformations_group_dtos.append(transformation_group_dto)
 
     return total_count, transformations_group_dtos

--- a/components/lif/mdr_services/transformation_service.py
+++ b/components/lif/mdr_services/transformation_service.py
@@ -967,7 +967,13 @@ async def get_paginated_transformations_groups(
 ):
     transformations_group_dtos: list[TransformationGroupDTO] = []
     # Query to count total transformations for pagination
-    total_query = select(func.count(TransformationGroup.Id)).where(TransformationGroup.Deleted == False)
+    total_query = select(func.count(TransformationGroup.Id)).where(
+        and_(
+            TransformationGroup.Deleted == False,
+            (TransformationGroup.SourceDataModelId == source_data_model_id if source_data_model_id else True),
+            (TransformationGroup.TargetDataModelId == target_data_model_id if target_data_model_id else True),
+        )
+    )
     total_result = await session.execute(total_query)
     total_count = total_result.scalar()
 

--- a/test/bases/lif/learner_data_export_api/test_core.py
+++ b/test/bases/lif/learner_data_export_api/test_core.py
@@ -35,35 +35,85 @@ async def test_available_data_formats_401():
 
 
 async def test_available_data_formats_default_token():
-    async with get_client() as client:
-        response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
-        assert response.status_code == 200
-        response_json = response.json()
-        expected_response = {
-            "metadata": {"total": 3},
-            "DataFormats": [
-                {
-                    "name": "OpenBadges 3.0",
-                    "version": "1.0.3",
-                    "contributorOrganization": "OB",
-                    "TransformationVersions": ["1.0.0", "1.1.0"],
-                },
-                {
-                    "name": "CEDS",
-                    "version": "2.0.0",
-                    "contributorOrganization": "CEDS Org",
-                    "TransformationVersions": ["2.0.0"],
-                },
-                {
+    # Transformation groups as returned by MDR (exportable=true). OpenBadges appears
+    # in two groups (same target id) with versions out of order, and the rows are not
+    # name-sorted, to exercise the endpoint's grouping + sorting.
+    mdr_transformation_groups = {
+        "total": 4,
+        "data": [
+            {
+                "TargetDataModelId": 1,
+                "GroupVersion": "1.1.0",
+                "TargetDataModel": {"name": "OpenBadges 3.0", "version": "1.0.3", "contributorOrganization": "OB"},
+            },
+            {
+                "TargetDataModelId": 1,
+                "GroupVersion": "1.0.0",
+                "TargetDataModel": {"name": "OpenBadges 3.0", "version": "1.0.3", "contributorOrganization": "OB"},
+            },
+            {
+                "TargetDataModelId": 2,
+                "GroupVersion": "2.0.0",
+                "TargetDataModel": {"name": "CEDS", "version": "2.0.0", "contributorOrganization": "CEDS Org"},
+            },
+            {
+                "TargetDataModelId": 3,
+                "GroupVersion": "1.3.0",
+                "TargetDataModel": {
                     "name": "ExampleDataSource",
                     "version": "1.0.1",
                     "contributorOrganization": "Community",
-                    "TransformationVersions": ["1.3.0"],
                 },
-            ],
-        }
-        diff = DeepDiff(expected_response, response_json)
-        assert not diff, diff  # prints out the differences if any
+            },
+        ],
+    }
+
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = mock.Mock()
+    mock_response.json = mock.Mock(return_value=mdr_transformation_groups)
+
+    mock_mdr_client = mock.Mock()
+    mock_mdr_client.get = mock.AsyncMock(return_value=mock_response)
+
+    async def fake_get_mdr_client():
+        yield mock_mdr_client
+
+    with (
+        mock.patch("lif.mdr_client.core._get_mdr_client", new=fake_get_mdr_client),
+        mock.patch.object(_ep.CONFIG, "openapi_data_model_id", "17"),
+    ):
+        async with get_client() as client:
+            response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
+
+    assert response.status_code == 200, response.text
+    response_json = response.json()
+    # DataFormats sorted by name asc; OpenBadges TransformationVersions sorted asc.
+    expected_response = {
+        "metadata": {"total": 3},
+        "DataFormats": [
+            {
+                "name": "CEDS",
+                "version": "2.0.0",
+                "contributorOrganization": "CEDS Org",
+                "TransformationVersions": ["2.0.0"],
+            },
+            {
+                "name": "ExampleDataSource",
+                "version": "1.0.1",
+                "contributorOrganization": "Community",
+                "TransformationVersions": ["1.3.0"],
+            },
+            {
+                "name": "OpenBadges 3.0",
+                "version": "1.0.3",
+                "contributorOrganization": "OB",
+                "TransformationVersions": ["1.0.0", "1.1.0"],
+            },
+        ],
+    }
+    diff = DeepDiff(expected_response, response_json)
+    assert not diff, diff  # prints out the differences if any
 
 
 async def test_export_401():

--- a/test/bases/lif/learner_data_export_api/test_core.py
+++ b/test/bases/lif/learner_data_export_api/test_core.py
@@ -116,6 +116,130 @@ async def test_available_data_formats_default_token():
     assert not diff, diff  # prints out the differences if any
 
 
+def _fake_get_mdr_client(*, json_payload=None, get_side_effect=None):
+    """Build a replacement for mdr_client._get_mdr_client that yields a mock client.
+
+    Pass json_payload for a 200 response, or get_side_effect to make client.get raise.
+    """
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = mock.Mock()
+    mock_response.json = mock.Mock(return_value=json_payload)
+
+    mock_mdr_client = mock.Mock()
+    if get_side_effect is not None:
+        mock_mdr_client.get = mock.AsyncMock(side_effect=get_side_effect)
+    else:
+        mock_mdr_client.get = mock.AsyncMock(return_value=mock_response)
+
+    async def fake_get_mdr_client():
+        yield mock_mdr_client
+
+    return fake_get_mdr_client
+
+
+async def test_available_data_formats_empty():
+    with (
+        mock.patch(
+            "lif.mdr_client.core._get_mdr_client", new=_fake_get_mdr_client(json_payload={"total": 0, "data": []})
+        ),
+        mock.patch.object(_ep.CONFIG, "openapi_data_model_id", "17"),
+    ):
+        async with get_client() as client:
+            response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"metadata": {"total": 0}, "DataFormats": []}
+
+
+async def test_available_data_formats_mdr_error_returns_500():
+    with (
+        mock.patch(
+            "lif.mdr_client.core._get_mdr_client", new=_fake_get_mdr_client(get_side_effect=RuntimeError("boom"))
+        ),
+        mock.patch.object(_ep.CONFIG, "openapi_data_model_id", "17"),
+    ):
+        async with get_client() as client:
+            response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Unable to retrieve available data formats"}
+
+
+async def test_available_data_formats_skips_deduplicated_and_defaults():
+    # Exercises the grouping branches: a group with no TargetDataModelId is skipped,
+    # repeated GroupVersions for one target are deduped, and a missing TargetDataModel
+    # object falls back to empty-string name/version/org.
+    mdr_transformation_groups = {
+        "total": 5,
+        "data": [
+            {
+                "TargetDataModelId": 1,
+                "GroupVersion": "2.0",
+                "TargetDataModel": {"name": "Zeta", "version": "9.9", "contributorOrganization": "Z Org"},
+            },
+            {
+                "TargetDataModelId": 1,
+                "GroupVersion": "1.0",
+                "TargetDataModel": {"name": "Zeta", "version": "9.9", "contributorOrganization": "Z Org"},
+            },
+            {
+                # Duplicate version for target 1 -> deduped.
+                "TargetDataModelId": 1,
+                "GroupVersion": "1.0",
+                "TargetDataModel": {"name": "Zeta", "version": "9.9", "contributorOrganization": "Z Org"},
+            },
+            {
+                # No TargetDataModelId -> skipped entirely.
+                "GroupVersion": "5.0",
+                "TargetDataModel": {"name": "Ignored", "version": "1.0", "contributorOrganization": "X"},
+            },
+            {
+                # No TargetDataModel object -> name/version/org default to "".
+                "TargetDataModelId": 2,
+                "GroupVersion": "1.0",
+            },
+        ],
+    }
+
+    with (
+        mock.patch(
+            "lif.mdr_client.core._get_mdr_client", new=_fake_get_mdr_client(json_payload=mdr_transformation_groups)
+        ),
+        mock.patch.object(_ep.CONFIG, "openapi_data_model_id", "17"),
+    ):
+        async with get_client() as client:
+            response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
+
+    assert response.status_code == 200, response.text
+    # Two distinct targets; sorted by name asc puts the empty-name target first.
+    expected_response = {
+        "metadata": {"total": 2},
+        "DataFormats": [
+            {"name": "", "version": "", "contributorOrganization": "", "TransformationVersions": ["1.0"]},
+            {
+                "name": "Zeta",
+                "version": "9.9",
+                "contributorOrganization": "Z Org",
+                "TransformationVersions": ["1.0", "2.0"],
+            },
+        ],
+    }
+    diff = DeepDiff(expected_response, response.json())
+    assert not diff, diff
+
+
+async def test_available_data_formats_missing_config_returns_500():
+    with mock.patch.object(_ep.CONFIG, "openapi_data_model_id", None):
+        async with get_client() as client:
+            response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "detail": "OPENAPI_DATA_MODEL_ID is not configured. Unable to retrieve available data formats"
+    }
+
+
 async def test_export_401():
     async with get_client() as client:
         response = await client.get("/exports")

--- a/test/bases/lif/learner_data_export_api/test_core.py
+++ b/test/bases/lif/learner_data_export_api/test_core.py
@@ -152,6 +152,46 @@ async def test_available_data_formats_empty():
     assert response.json() == {"metadata": {"total": 0}, "DataFormats": []}
 
 
+async def test_available_data_formats_versions_sorted_numerically():
+    # "1.10.0" must sort after "1.9.0" (numeric, not lexical). Single numeric segments
+    # ("423") sort among the numeric-first-segment versions, while versions whose first
+    # segment is non-numeric ("1.a"/"1.c" share a numeric first segment, but "B.23.1",
+    # "E.43", "One" do not) fall back to lexical ordering after the numeric ones.
+    mdr_transformation_groups = {
+        "total": 9,
+        "data": [
+            {
+                "TargetDataModelId": 1,
+                "GroupVersion": gv,
+                "TargetDataModel": {"name": "Model", "version": "1.0", "contributorOrganization": "Org"},
+            }
+            for gv in ("B.23.1", "1.10.0", "One", "1.c", "1.a", "423", "1.2.0", "E.43", "1.9.0")
+        ],
+    }
+
+    with (
+        mock.patch(
+            "lif.mdr_client.core._get_mdr_client", new=_fake_get_mdr_client(json_payload=mdr_transformation_groups)
+        ),
+        mock.patch.object(_ep.CONFIG, "openapi_data_model_id", "17"),
+    ):
+        async with get_client() as client:
+            response = await client.get("/available-data-formats", headers={"X-API-Key": DEFAULT_API_KEY})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["DataFormats"][0]["TransformationVersions"] == [
+        "1.2.0",
+        "1.9.0",
+        "1.10.0",
+        "1.a",
+        "1.c",
+        "423",
+        "B.23.1",
+        "E.43",
+        "One",
+    ]
+
+
 async def test_available_data_formats_mdr_error_returns_500():
     with (
         mock.patch(

--- a/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
+++ b/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
@@ -763,3 +763,53 @@ async def test_update_transform_only_expression(async_client_mdr, async_client_t
         headers=mdr_api_headers,
     )
     assert translated_json == {"User": {"Skills": {"Genre": {"Grade": "K"}}}}
+
+
+@pytest.mark.asyncio
+async def test_get_transformation_groups_exportable(async_client_mdr, mdr_api_headers):
+    """
+    The transformation-groups listing carries portable (name, version, org) refs for
+    source/target only when exportable=true; otherwise those fields stay null.
+    """
+
+    test_case_name = inspect.currentframe().f_code.co_name
+
+    dataset = await DatasetTransformDeepLiteralAttribute.prepare(
+        async_client_mdr=async_client_mdr,
+        source_data_model_name=f"{test_case_name}_source",
+        target_data_model_name=f"{test_case_name}_target",
+        transformation_group_name=f"{test_case_name}_transform_group",
+    )
+
+    # exportable=true -> each group includes the portable source/target refs.
+    response = await async_client_mdr.get(
+        "/transformation_groups/",
+        headers=mdr_api_headers,
+        params={"source_data_model_id": dataset.source_data_model_id, "exportable": "true", "pagination": "false"},
+    )
+    assert response.status_code == 200, response.text
+    groups = response.json()["data"]
+    group = next(g for g in groups if g["Id"] == dataset.transformation_group_id)
+
+    # Data models created via upload use version "1.0" with no contributor organization.
+    assert group["SourceDataModel"] == {
+        "name": f"{test_case_name}_source",
+        "version": "1.0",
+        "contributorOrganization": None,
+    }
+    assert group["TargetDataModel"] == {
+        "name": f"{test_case_name}_target",
+        "version": "1.0",
+        "contributorOrganization": None,
+    }
+
+    # Default (exportable not set) -> portable refs are null.
+    response = await async_client_mdr.get(
+        "/transformation_groups/",
+        headers=mdr_api_headers,
+        params={"source_data_model_id": dataset.source_data_model_id, "pagination": "false"},
+    )
+    assert response.status_code == 200, response.text
+    group = next(g for g in response.json()["data"] if g["Id"] == dataset.transformation_group_id)
+    assert group["SourceDataModel"] is None
+    assert group["TargetDataModel"] is None

--- a/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
+++ b/test/bases/lif/mdr_restapi/test_transformation_endpoint.py
@@ -369,6 +369,8 @@ async def test_transforms_with_embeddings(async_client_mdr, async_client_transla
         "TargetDataModelId": target_data_model_id,
         "SourceDataModelName": f"{test_case_name}_source",
         "TargetDataModelName": f"{test_case_name}_target",
+        "SourceDataModel": None,
+        "TargetDataModel": None,
         "Name": f"{test_case_name}_transform_group",
         "GroupVersion": "1.0",
         "Description": group_description,

--- a/test/components/lif/mdr_client/test_core.py
+++ b/test/components/lif/mdr_client/test_core.py
@@ -1,6 +1,7 @@
 import asyncio
 import httpx
 import os
+import types
 import pytest
 from unittest import mock
 from unittest.mock import patch, MagicMock
@@ -229,6 +230,34 @@ def test_get_data_model_transformation_not_found(mock_get):
     with pytest.raises(ResourceNotFoundException) as exc_info:
         asyncio.run(run_test())
     assert "Transformation from 25 to 17 not found in MDR." in str(exc_info.value)
+
+
+@patch("httpx.AsyncClient.get")
+async def test_get_transformation_groups_from_mdr_success(mock_get):
+    config = types.SimpleNamespace(mdr_api_url="http://api.example.com")
+    expected_url = (
+        "http://api.example.com/transformation_groups/"
+        "?exportable=True&pagination=False&size=100&source_data_model_id=17"
+    )
+    payload = {"total": 1, "data": [{"TargetDataModelId": 2, "GroupVersion": "1.0"}]}
+    mock_get.return_value = _create_mock_response(200, payload, expected_url)
+
+    result = await core.get_transformation_groups_from_mdr(config=config, source_data_model_id="17")
+
+    assert result == payload
+    mock_get.assert_called_once()
+    assert mock_get.call_args[0][0] == expected_url
+
+
+@patch("httpx.AsyncClient.get")
+async def test_get_transformation_groups_from_mdr_raises_on_http_error(mock_get):
+    config = types.SimpleNamespace(mdr_api_url="http://api.example.com")
+    mock_get.return_value = _create_mock_response(
+        500, {"detail": "boom"}, "http://api.example.com/transformation_groups/"
+    )
+
+    with pytest.raises(core.MDRClientException):
+        await core.get_transformation_groups_from_mdr(config=config, source_data_model_id="17")
 
 
 def _create_mock_response(status_code: int, json_data, uri: str):

--- a/test/components/lif/mdr_client/test_core.py
+++ b/test/components/lif/mdr_client/test_core.py
@@ -234,24 +234,30 @@ def test_get_data_model_transformation_not_found(mock_get):
 
 @patch("httpx.AsyncClient.get")
 async def test_get_transformation_groups_from_mdr_success(mock_get):
-    config = types.SimpleNamespace(mdr_api_url="http://api.example.com")
-    expected_url = (
-        "http://api.example.com/transformation_groups/"
-        "?exportable=True&pagination=False&size=100&source_data_model_id=17"
-    )
+    config = types.SimpleNamespace(mdr_api_url="http://api.example.com", mdr_api_auth_token="secret-token")
+    url = "http://api.example.com/transformation_groups/"
     payload = {"total": 1, "data": [{"TargetDataModelId": 2, "GroupVersion": "1.0"}]}
-    mock_get.return_value = _create_mock_response(200, payload, expected_url)
+    mock_get.return_value = _create_mock_response(200, payload, url)
 
     result = await core.get_transformation_groups_from_mdr(config=config, source_data_model_id="17")
 
     assert result == payload
     mock_get.assert_called_once()
-    assert mock_get.call_args[0][0] == expected_url
+    # URL is the bare path; query args are passed via params (httpx encodes them).
+    assert mock_get.call_args.args[0] == url
+    assert mock_get.call_args.kwargs["params"] == {
+        "source_data_model_id": "17",
+        "exportable": True,
+        "pagination": False,
+        "size": 100,
+    }
+    # Auth token is sourced from config, not the environment.
+    assert mock_get.call_args.kwargs["headers"]["X-API-Key"] == "secret-token"
 
 
 @patch("httpx.AsyncClient.get")
 async def test_get_transformation_groups_from_mdr_raises_on_http_error(mock_get):
-    config = types.SimpleNamespace(mdr_api_url="http://api.example.com")
+    config = types.SimpleNamespace(mdr_api_url="http://api.example.com", mdr_api_auth_token="secret-token")
     mock_get.return_value = _create_mock_response(
         500, {"detail": "boom"}, "http://api.example.com/transformation_groups/"
     )


### PR DESCRIPTION
Implements the logic for the LDE `/available-data-models` endpoint, serviced by the paginated transformation_groups MDR endpoint.