### PR TITLE
chore: release-demo 2026-06-29 — pin demo image tags to current dev builds

### DIFF
--- a/cloudformation/demo-lif-graphql-org1.params
+++ b/cloudformation/demo-lif-graphql-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-24-19-49-25-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org2.params
+++ b/cloudformation/demo-lif-graphql-org2.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-24-19-49-25-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql-org3.params
+++ b/cloudformation/demo-lif-graphql-org3.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-24-19-49-25-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-graphql.params
+++ b/cloudformation/demo-lif-graphql.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-19-20-11-28-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_graphql_api:2026-06-24-19-49-25-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-learner-data-export-api.params
+++ b/cloudformation/demo-lif-learner-data-export-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-06-23-21-36-30-43b2084"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-06-24-19-49-24-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-06-19-20-11-29-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-06-24-19-49-30-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-semantic-search.params
+++ b/cloudformation/demo-lif-semantic-search.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_semantic_search_mcp_server:2026-06-19-20-13-08-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_semantic_search_mcp_server:2026-06-24-19-52-52-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-translator-org1.params
+++ b/cloudformation/demo-lif-translator-org1.params
@@ -53,7 +53,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_translator_api:2026-06-19-20-11-33-0025436"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_translator_api:2026-06-24-19-49-25-328d493"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
## What

Promotes 8 demo services to dev build \`328d493\` (the #1022 merge build).

#1022 (available-data-formats) changed shared MDR components (\`mdr_client\` / \`mdr_services\` / \`mdr_dto\`), so the monorepo CI rebuilt every service that depends on them. Promoting them together keeps the new LDE \`/available-data-formats\` endpoint consistent with the new MDR \`exportable\` param.

| Stack | From → To |
|-------|-----------|
| graphql-org1/2/3 (+ base) | 0025436 → 328d493 |
| learner-data-export-api | 43b2084 → 328d493 |
| mdr-api | 0025436 → 328d493 |
| semantic-search | 0025436 → 328d493 |
| translator-org1 | 0025436 → 328d493 |

The other 26 services don't depend on the changed components → unchanged (`release-demo` reports them already current).

## Notes
- graphql image is pre-#1012; safe because the demo MDR field rename (attrs 1404/1405/1406, hyphen→underscore) is in place (verified pre-deploy).
- Does not address the demo `/exports` ELM/HR-Open transformation-mapping content gap (separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)