### PR TITLE
Issue #1031: fix eslint rule-name typo unblocking mdr-frontend lint

### DIFF
--- a/frontends/mdr-frontend/eslint.config.js
+++ b/frontends/mdr-frontend/eslint.config.js
@@ -24,7 +24,7 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       "@typescript-eslint/no-unused-vars": ["warn"],
-      "@typescript-eslint/no-explicite-any": ["warn"],
+      "@typescript-eslint/no-explicit-any": ["warn"],
     },
   }
 );


### PR DESCRIPTION
Fixes #1031.

`frontends/mdr-frontend/eslint.config.js` referenced `@typescript-eslint/no-explicite-any` (misspelled — extra "e"). ESLint 9 validates rule names on config load, so it threw `TypeError: Could not find "no-explicite-any"` and **`npm run lint` crashed for the entire mdr-frontend** (no linting ran at all).

One-char fix: `no-explicite-any` → `no-explicit-any`, keeping the intended `["warn"]` level. Verified ESLint now loads and lints (surfaces the expected `no-explicit-any` / `no-unused-vars` warnings instead of throwing).

Found while working #1028 (used `tsc` to type-check the frontend since lint was unusable).

##### Type of Change
- [x] Bug fix (non-breaking)
- [x] frontends/

🤖 Generated with [Claude Code](https://claude.com/claude-code)