### PR TITLE
Issue #1033: MDR developer-keys store + key-management endpoints

### DIFF
--- a/bases/lif/mdr_restapi/core.py
+++ b/bases/lif/mdr_restapi/core.py
@@ -8,6 +8,7 @@ from lif.mdr_restapi import (
     attribute_endpoints,
     datamodel_constraints_endpoints,
     datamodel_endpoints,
+    developer_api_key_endpoints,
     entity_association_endpoints,
     entity_attribute_association_endpoints,
     entity_endpoints,
@@ -479,6 +480,7 @@ app.include_router(generate_jinja_endpoint.router, prefix="/generate_jinja")
 app.include_router(datamodel_constraints_endpoints.router, prefix="/datamodel_constraints")
 
 app.include_router(tenant_endpoints.router, prefix="/tenants")
+app.include_router(developer_api_key_endpoints.router, prefix="/api-keys")
 
 
 # API Key Management Endpoints

--- a/bases/lif/mdr_restapi/developer_api_key_endpoints.py
+++ b/bases/lif/mdr_restapi/developer_api_key_endpoints.py
@@ -1,0 +1,49 @@
+"""Developer API key endpoints (#1033).
+
+Cognito-authed CRUD for a user's personal API keys (used by downstream apps against the LDE
+/exports API). Keys are scoped to the caller's Cognito `sub` (ownership) and their selected
+workspace (the tenant schema is already set on the request via search_path by the auth
+middleware / get_session, so no explicit tenant handling is needed here).
+"""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from lif.mdr_dto.developer_api_key_dto import CreatedDeveloperApiKeyDTO, CreateDeveloperApiKeyDTO, DeveloperApiKeyDTO
+from lif.mdr_services import developer_api_key_service
+from lif.mdr_utils.database_setup import get_session
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter()
+
+
+def _require_owner_sub(request: Request) -> str:
+    """Return the caller's Cognito `sub` (the key owner).
+
+    Rejects service-principal (API-key) callers — they have no Cognito identity, so they can't
+    own personal keys.
+    """
+    sub = getattr(request.state, "cognito_sub", None)
+    if not sub:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Requires a signed-in Cognito user")
+    return sub
+
+
+@router.post("/", response_model=CreatedDeveloperApiKeyDTO, status_code=status.HTTP_201_CREATED)
+async def create_api_key(
+    data: CreateDeveloperApiKeyDTO, request: Request, session: AsyncSession = Depends(get_session)
+):
+    owner_sub = _require_owner_sub(request)
+    return await developer_api_key_service.create_developer_api_key(session, owner_sub, data)
+
+
+@router.get("/", response_model=List[DeveloperApiKeyDTO])
+async def list_api_keys(request: Request, session: AsyncSession = Depends(get_session)):
+    owner_sub = _require_owner_sub(request)
+    return await developer_api_key_service.list_developer_api_keys(session, owner_sub)
+
+
+@router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_api_key(key_id: int, request: Request, session: AsyncSession = Depends(get_session)):
+    owner_sub = _require_owner_sub(request)
+    await developer_api_key_service.revoke_developer_api_key(session, owner_sub, key_id)

--- a/components/lif/datatypes/mdr_sql_model.py
+++ b/components/lif/datatypes/mdr_sql_model.py
@@ -439,3 +439,23 @@ class ExtMappedValueSet(SQLModel, table=True):
     # mapped_value_set: Optional["ValueSet"] = Relationship(
     #     sa_relationship_kwargs={"foreign_keys": "[ExtMappedValueSet.MappedValueSetId]"}
     # )
+
+
+class DeveloperApiKey(SQLModel, table=True):
+    """User-owned API key for programmatic access to the LDE /exports API (#1033).
+
+    Lives in the tenant schema (workspace-scoped via search_path) and is further scoped to a
+    user by OwnerSub (the Cognito `sub`). The raw key is returned to the caller exactly once
+    on creation and never stored — only its SHA-256 hash (KeyHash) plus a display prefix.
+    """
+
+    __tablename__ = "DeveloperApiKeys"
+    Id: Optional[int] = Field(default=None, primary_key=True)
+    OwnerSub: str = Field(index=True)
+    Label: str
+    KeyPrefix: str
+    KeyHash: str = Field(index=True)
+    CreationDate: datetime = Field(sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False))
+    LastUsedDate: Optional[datetime] = Field(default=None, sa_column=Column(DateTime(timezone=True)))
+    RevokedDate: Optional[datetime] = Field(default=None, sa_column=Column(DateTime(timezone=True)))
+    ExpirationDate: Optional[datetime] = Field(default=None, sa_column=Column(DateTime(timezone=True)))

--- a/components/lif/mdr_dto/developer_api_key_dto.py
+++ b/components/lif/mdr_dto/developer_api_key_dto.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class CreateDeveloperApiKeyDTO(BaseModel):
+    Label: str
+
+
+class DeveloperApiKeyDTO(BaseModel):
+    """Listing view — never includes the raw key."""
+
+    Id: int
+    Label: str
+    KeyPrefix: str
+    CreationDate: datetime
+    LastUsedDate: Optional[datetime] = None
+    RevokedDate: Optional[datetime] = None
+
+    class Config:
+        orm_mode = True
+        from_attributes = True
+
+
+class CreatedDeveloperApiKeyDTO(BaseModel):
+    """Create response — includes the raw key, returned exactly once and never again."""
+
+    Id: int
+    Label: str
+    KeyPrefix: str
+    CreationDate: datetime
+    Key: str

--- a/components/lif/mdr_services/developer_api_key_service.py
+++ b/components/lif/mdr_services/developer_api_key_service.py
@@ -1,0 +1,63 @@
+"""Developer API key management (#1033).
+
+User-owned keys for programmatic access to the LDE /exports API. Keys are workspace-scoped
+(they live in the tenant schema, reached via the request's search_path) and user-scoped by
+OwnerSub (the Cognito `sub`). The raw key is generated + returned exactly once; only its
+SHA-256 hash is stored. Revocation is a soft state (RevokedDate).
+"""
+
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from typing import List, Tuple
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from lif.datatypes.mdr_sql_model import DeveloperApiKey
+from lif.mdr_dto.developer_api_key_dto import CreatedDeveloperApiKeyDTO, CreateDeveloperApiKeyDTO, DeveloperApiKeyDTO
+
+KEY_PREFIX = "lifk_"
+_PREFIX_DISPLAY_LEN = 12  # leading chars kept for display (never the full key)
+
+
+def _generate_key() -> Tuple[str, str, str]:
+    """Return ``(raw_key, key_prefix, key_hash)``.
+
+    The raw key is high-entropy (``secrets.token_urlsafe(32)``), so a plain SHA-256 at rest is
+    sufficient (no salt/KDF needed — unlike low-entropy passwords). The raw key is returned to the
+    caller once and never stored.
+    """
+    raw = f"{KEY_PREFIX}{secrets.token_urlsafe(32)}"
+    key_hash = hashlib.sha256(raw.encode()).hexdigest()
+    return raw, raw[:_PREFIX_DISPLAY_LEN], key_hash
+
+
+async def create_developer_api_key(
+    session: AsyncSession, owner_sub: str, data: CreateDeveloperApiKeyDTO
+) -> CreatedDeveloperApiKeyDTO:
+    raw, key_prefix, key_hash = _generate_key()
+    key = DeveloperApiKey(OwnerSub=owner_sub, Label=data.Label, KeyPrefix=key_prefix, KeyHash=key_hash)
+    session.add(key)
+    await session.commit()
+    await session.refresh(key)
+    return CreatedDeveloperApiKeyDTO(
+        Id=key.Id, Label=key.Label, KeyPrefix=key.KeyPrefix, CreationDate=key.CreationDate, Key=raw
+    )
+
+
+async def list_developer_api_keys(session: AsyncSession, owner_sub: str) -> List[DeveloperApiKeyDTO]:
+    result = await session.execute(select(DeveloperApiKey).where(DeveloperApiKey.OwnerSub == owner_sub))
+    return [DeveloperApiKeyDTO.from_orm(key) for key in result.scalars().all()]
+
+
+async def revoke_developer_api_key(session: AsyncSession, owner_sub: str, key_id: int) -> None:
+    key = await session.get(DeveloperApiKey, key_id)
+    # 404 (not 403) when the key isn't the caller's, so we don't reveal other users' key ids.
+    if key is None or key.OwnerSub != owner_sub:
+        raise HTTPException(status_code=404, detail="API key not found")
+    if key.RevokedDate is None:
+        key.RevokedDate = datetime.now(timezone.utc)
+        session.add(key)
+        await session.commit()

--- a/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.5__developer_api_keys.sql
+++ b/sam/mdr-database/flyway/flyway-files/flyway/sql/mdr/V1.5__developer_api_keys.sql
@@ -1,0 +1,41 @@
+-- Issue #1033: DeveloperApiKeys — user-owned API keys for programmatic access to the LDE /exports API.
+--
+-- Keys are minted / listed / revoked via the MDR API (Cognito-authed) and stored HASHED
+-- (the raw key is returned to the caller exactly once, never persisted). A key is scoped to a
+-- workspace by living in that tenant's schema (request-time search_path), and to a user by OwnerSub
+-- (the Cognito `sub`).
+--
+-- Idempotent per the CLAUDE.md "MDR Schema Migrations (V1.2+)" convention (safe to replay).
+--   1. Create the table in `public` so future clone_lif_schema() runs copy it into new tenant
+--      schemas automatically (clone_lif_schema copies every public table via LIKE ... INCLUDING ALL).
+--   2. Back-fill tenant schemas already provisioned before this table existed (e.g. tenant_lif_team) —
+--      clone_lif_schema already ran for them, so they won't retroactively get the new table.
+
+CREATE TABLE IF NOT EXISTS public."DeveloperApiKeys" (
+    "Id"             integer     GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    "OwnerSub"       varchar     NOT NULL,
+    "Label"          varchar     NOT NULL,
+    "KeyPrefix"      varchar     NOT NULL,
+    "KeyHash"        varchar     NOT NULL,
+    "CreationDate"   timestamptz NOT NULL DEFAULT now(),
+    "LastUsedDate"   timestamptz,
+    "RevokedDate"    timestamptz,
+    "ExpirationDate" timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS "ix_DeveloperApiKeys_OwnerSub" ON public."DeveloperApiKeys" ("OwnerSub");
+CREATE INDEX IF NOT EXISTS "ix_DeveloperApiKeys_KeyHash"  ON public."DeveloperApiKeys" ("KeyHash");
+
+-- Back-fill existing tenant_* schemas (cloned before this table existed).
+DO $$
+DECLARE
+    schema_name text;
+BEGIN
+    FOR schema_name IN SELECT nspname FROM pg_namespace WHERE nspname ~ '^tenant_'
+    LOOP
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I."DeveloperApiKeys" (LIKE public."DeveloperApiKeys" INCLUDING ALL)',
+            schema_name
+        );
+    END LOOP;
+END $$;

--- a/test/bases/lif/mdr_restapi/test_developer_api_key_service.py
+++ b/test/bases/lif/mdr_restapi/test_developer_api_key_service.py
@@ -1,0 +1,72 @@
+"""Developer API key service (#1033).
+
+Keys are created with the raw value returned once and stored hashed; listing/revocation are
+scoped to the owning Cognito `sub`. Drives the real service against a live Postgres
+(``test_db_session``). The fixture DB is only the V1.1 baseline (backup.sql) and does not replay
+the V1.5 migration, so the ``dev_keys_table`` fixture creates the table. Owners are keyed off the
+test name (``request.node.name``) since the DB is shared across tests.
+"""
+
+import hashlib
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import select
+
+from lif.datatypes.mdr_sql_model import DeveloperApiKey
+from lif.mdr_dto.developer_api_key_dto import CreateDeveloperApiKeyDTO
+from lif.mdr_services.developer_api_key_service import (
+    create_developer_api_key,
+    list_developer_api_keys,
+    revoke_developer_api_key,
+)
+
+
+@pytest.fixture
+async def dev_keys_table(test_db_session):
+    engine = test_db_session.bind
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: DeveloperApiKey.__table__.create(c, checkfirst=True))
+    yield
+
+
+async def test_create_stores_hash_and_returns_raw_key_once(test_db_session, dev_keys_table, request):
+    session = test_db_session
+    owner = request.node.name
+
+    created = await create_developer_api_key(session, owner, CreateDeveloperApiKeyDTO(Label="my app"))
+
+    assert created.Key.startswith("lifk_")
+    assert created.KeyPrefix == created.Key[:12]
+    # Stored hashed — the raw key is never persisted.
+    row = (await session.execute(select(DeveloperApiKey).where(DeveloperApiKey.Id == created.Id))).scalars().one()
+    assert row.KeyHash == hashlib.sha256(created.Key.encode()).hexdigest()
+    assert row.KeyHash != created.Key
+
+
+async def test_list_is_scoped_to_owner_and_omits_raw_key(test_db_session, dev_keys_table, request):
+    session = test_db_session
+    owner_a, owner_b = f"{request.node.name}-a", f"{request.node.name}-b"
+
+    a1 = await create_developer_api_key(session, owner_a, CreateDeveloperApiKeyDTO(Label="a1"))
+    await create_developer_api_key(session, owner_b, CreateDeveloperApiKeyDTO(Label="b1"))
+
+    keys = await list_developer_api_keys(session, owner_a)
+    assert [k.Id for k in keys] == [a1.Id]  # only owner_a's key
+    assert not hasattr(keys[0], "Key")  # listing never exposes the raw key
+
+
+async def test_revoke_sets_revoked_date_and_enforces_ownership(test_db_session, dev_keys_table, request):
+    session = test_db_session
+    owner, other = f"{request.node.name}-owner", f"{request.node.name}-other"
+
+    created = await create_developer_api_key(session, owner, CreateDeveloperApiKeyDTO(Label="k"))
+
+    # A different user cannot revoke it — 404 (not 403), so other users' key ids aren't revealed.
+    with pytest.raises(HTTPException) as exc:
+        await revoke_developer_api_key(session, other, created.Id)
+    assert exc.value.status_code == 404
+
+    await revoke_developer_api_key(session, owner, created.Id)
+    row = (await session.execute(select(DeveloperApiKey).where(DeveloperApiKey.Id == created.Id))).scalars().one()
+    assert row.RevokedDate is not None


### PR DESCRIPTION
Part of #1000 (LDE self-service API keys). Backend foundation so a signed-in user can mint / list / revoke personal API keys via the MDR API — **unblocks the MDR UI page (#1035)**. Implements the contract from #1033.

## What's here
- **`DeveloperApiKey` model + `V1.5` migration.** Table created in `public` so `clone_lif_schema` copies it into future tenant schemas automatically, **plus a back-fill loop** over existing `tenant_*` schemas (which were cloned before the table existed). Idempotent (`CREATE ... IF NOT EXISTS`) per the migration convention.
- **Cognito-authed `/api-keys` router** (create / list / revoke), auto-protected by `AuthMiddleware`. Scoped to the caller's `cognito_sub` (ownership) and their workspace (tenant schema via request `search_path` — no explicit tenant handling needed).
- **Key handling:** generated as `lifk_<token_urlsafe(32)>`, stored **SHA-256-hashed** (raw key returned exactly once on create, never again); list exposes only `KeyPrefix`; revoke is a soft `RevokedDate`; non-owner revoke → 404 (doesn't reveal ids).

## API (contract)
- `POST /api-keys` `{label}` → `201 {id,label,keyPrefix,createdAt,key}` (raw key once)
- `GET /api-keys` → `200 [{id,label,keyPrefix,createDate,lastUsedDate,revokedDate}]`
- `DELETE /api-keys/{id}` → `204` (soft-revoke; 404 if not the caller's)

## Tests
Integration tests (live Postgres) cover: hashed-at-rest + raw-returned-once, owner-scoped listing, and revoke + ownership enforcement. Full `mdr_restapi` suite green (72), ruff/format clean.

## Scope / next
- This is the **store + management CRUD only.** LDE-side *validation* of these keys (offline signed-token vs. hashed-lookup) is **#1034**; the MDR UI page is **#1035**.
- Deploy note: the endpoint goes live once merged + the `V1.5` migration runs on the env's MDR DB.

##### Type of Change
- [x] New feature (non-breaking)
- [x] API endpoints
- [x] Database schema (migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)