### PR TITLE
Issue #1037: Remove unused MDR Client wrapper parameter

### DIFF
--- a/components/lif/mdr_client/core.py
+++ b/components/lif/mdr_client/core.py
@@ -283,7 +283,6 @@ async def get_transformation_groups_from_mdr(*, config: "LIFSchemaConfig", sourc
         "source_data_model_id": source_data_model_id,
         "exportable": True,
         "pagination": False,
-        "size": 100,
     }
     headers = _build_mdr_headers(config.mdr_api_auth_token)
 

--- a/test/components/lif/mdr_client/test_core.py
+++ b/test/components/lif/mdr_client/test_core.py
@@ -249,7 +249,6 @@ async def test_get_transformation_groups_from_mdr_success(mock_get):
         "source_data_model_id": "17",
         "exportable": True,
         "pagination": False,
-        "size": 100,
     }
     # Auth token is sourced from config, not the environment.
     assert mock_get.call_args.kwargs["headers"]["X-API-Key"] == "secret-token"


### PR DESCRIPTION
##### Description of Change

Removed an unused parameter in the MDR Client get transformation groups wrapper call.

##### Related Issues

As per #1037 


##### Type of Change
<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/deployment change
- [ ] Performance improvement
- [x] Code refactoring

##### Project Area(s) Affected
<!-- Check all project areas affected by this change -->

- [ ] bases/
- [x] components/
- [ ] projects/
- [ ] orchestrators/
- [ ] frontends/
- [ ] deployments/
- [ ] cloudformation/ or sam/ templates
- [ ] reference_data/
- [ ] scripts/
- [ ] test/ or e2e/
- [ ] Database schema (migrations)
- [ ] API endpoints
- [ ] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)

---

##### Checklist
<!-- REMOVE ITEMS that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] tests are included (unit and/or integration tests)
- [ ] documentation is changed or added (in /docs directory)
- [ ] code passes linting checks (`uv run ruff check`)
- [ ] code passes formatting checks (`uv run ruff format`)
- [ ] code passes type checking (`uv run ty check`)
- [x] pre-commit hooks have been run successfully
  - Except for 3 unrelated ty issues 
- [ ] database schema changes: migration files created and CHANGELOG.md updated
- [ ] API changes: base (Python code) documentation in `docs/`
      and project README updated
- [ ] configuration changes: relevant folder README updated
- [ ] breaking changes: added to MIGRATION.md with upgrade instructions
      and CHANGELOG.md entry

##### Testing
<!-- Describe the testing you've done -->

- [ ] Manual testing performed
- [ ] Automated tests added/updated
- [ ] Integration testing completed

##### Additional Notes
<!-- Any additional information that reviewers should know -->
