### PR TITLE
chore: release-demo 2026-07-14 — pin demo mdr-api + LDE to dev build 190bb25

### DIFF
--- a/cloudformation/demo-lif-learner-data-export-api.params
+++ b/cloudformation/demo-lif-learner-data-export-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-06-24-19-49-24-328d493"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-07-08-23-34-57-190bb25"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-06-24-19-49-30-328d493"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-07-08-23-34-54-190bb25"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
## What
Promotes the two demo services that changed in dev since the 06-29 sync (`328d493`) to `190bb25`:

| Stack | From → To |
|-------|-----------|
| mdr-api | 328d493 → 190bb25 (#1030 create-attribute atomic fix) |
| learner-data-export-api | 328d493 → 190bb25 (#1025 api-key auth + #1030) |

The other 32 services are unchanged (already `328d493`).

## Notes
- **LDE inbound auth changes on demo:** the new image (#1025) uses `api_key_auth` instead of the old `mdr_auth`/`changeme6` default. Demo `LDE_AUTH__API_KEYS` keys were provisioned in SSM before deploy, so the task starts and only the generated keys authenticate (closes the #1000 default-token gap on demo).
- mdr-api promotion is backward-compatible (#1030's optional `EntityId`).
- mdr-frontend is out of scope (deploys as an S3 site separately; #1039's API-keys page isn't merged yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)