### PR TITLE
Issue #1047: Build advisor-app per-environment so demo stops calling the dev backend

### DIFF
--- a/.github/workflows/lif_advisor_app.yml
+++ b/.github/workflows/lif_advisor_app.yml
@@ -10,15 +10,31 @@ permissions:
       id-token: write
       contents: read
 
+# NOTE: the advisor-app is a Vite SPA. Its API base URL is baked into the JS
+# bundle at BUILD time (see frontends/lif_advisor_app/Dockerfile), so the image
+# is environment-specific and CANNOT be promoted dev->demo like the backend
+# services. The target environment therefore selects which advisor-api URL is
+# baked in and which ECR repo the image is pushed to. See issue #1047.
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: >-
+          Target environment (selects the advisor-api URL baked into the bundle
+          and the ECR repo). The dev CI role can only push to lif/dev/*; building
+          'demo' from CI requires granting that role push access to
+          lif/demo/lif_advisor_app. Until then, build the demo image with admin
+          creds via frontends/lif_advisor_app/build-push.sh during promotion.
+        type: choice
+        options: [dev, demo]
+        default: dev
   push:
     branches: [ "main" ]
     paths:
       - .github/workflows/lif_advisor_app.yml
       - frontends/lif_advisor_app/**
       - cloudformation/dev-lif-advisor-api.params
-      - cloudformation/lif-advisor-taskdef-includes.yml
+      - cloudformation/lif-advisor-app-taskdef-includes.yml
 
 jobs:
 
@@ -30,11 +46,25 @@ jobs:
         shell: bash
     env:
       WORKING_DIR: ./frontends/lif_advisor_app
-      ECR_REPOSITORY: lif/dev/lif_advisor_app
-      VITE_LIF_ADVISOR_API_URL: 'https://advisor-api.dev.lif.unicon.net'
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Resolve environment config
+      id: cfg
+      run: |
+        ENVIRONMENT="${{ github.event.inputs.environment || 'dev' }}"
+        case "$ENVIRONMENT" in
+          dev)  API_URL="https://advisor-api.dev.lif.unicon.net" ;;
+          demo) API_URL="https://advisor-api.demo.lif.unicon.net" ;;
+          *)    echo "unknown environment: $ENVIRONMENT (expected dev|demo)"; exit 1 ;;
+        esac
+        echo "environment=$ENVIRONMENT" >> "$GITHUB_OUTPUT"
+        echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
+        echo "ecr_repository=lif/${ENVIRONMENT}/lif_advisor_app" >> "$GITHUB_OUTPUT"
+        # Only dev auto-deploys from CI (dev cluster + dev role). Demo is a manual promotion.
+        [ "$ENVIRONMENT" = "dev" ] && echo "deploy=true" >> "$GITHUB_OUTPUT" || echo "deploy=false" >> "$GITHUB_OUTPUT"
+        echo "Building advisor-app for '$ENVIRONMENT' (API=$API_URL)"
 
     - name: Setup Node.js 20
       uses: actions/setup-node@v1
@@ -54,12 +84,13 @@ jobs:
         github-actions-role: ${{ env.GHA_ROLE }}
         role-session-name: advisor-app-build
         aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
+        ecr-repository: ${{ steps.cfg.outputs.ecr_repository }}
         build-args: |
-          LIF_ADVISOR_API_URL=https://advisor-api.dev.lif.unicon.net
+          LIF_ADVISOR_API_URL=${{ steps.cfg.outputs.api_url }}
           GA_MEASUREMENT_ID=G-WCYGBK4XHK
 
     - name: Update the lif-advisor-app ECS Service
+      if: steps.cfg.outputs.deploy == 'true'
       uses: ./.github/actions/update-cluster
       with:
         github-actions-role: ${{ env.GHA_ROLE }}
@@ -67,4 +98,3 @@ jobs:
         aws-region: ${{ env.AWS_REGION }}
         ecs-cluster: ${{ env.ECS_CLUSTER }}
         ecs-service: ${{ env.ECS_SERVICE }}
-

--- a/cloudformation/demo-lif-advisor-app.params
+++ b/cloudformation/demo-lif-advisor-app.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/demo/lif_advisor_app:latest"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/demo/lif_advisor_app:2026-07-15-17-36-44-1c04632"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/demo-lif-advisor-app.params
+++ b/cloudformation/demo-lif-advisor-app.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_advisor_app:2026-06-23-15-54-56-66cd748"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/demo/lif_advisor_app:latest"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",

--- a/cloudformation/lif-advisor-app-taskdef-includes.yml
+++ b/cloudformation/lif-advisor-app-taskdef-includes.yml
@@ -1,3 +1,10 @@
+# NOTE: LIF_ADVISOR_API_URL below is INERT for the advisor-app container.
+# The app is a Vite SPA served as static files by nginx; its API base URL is
+# baked into the JS bundle at BUILD time (VITE_LIF_ADVISOR_API_URL — see
+# frontends/lif_advisor_app/Dockerfile and build-push.sh), NOT read from this
+# runtime env var. It is kept only so the task definition Environment block is
+# non-empty. To change the API URL the browser calls, rebuild the image with
+# the correct --build-arg for the target environment. See issue #1047.
 Environment:
   - Name: LIF_ADVISOR_API_URL
     Value:

--- a/frontends/lif_advisor_app/Dockerfile
+++ b/frontends/lif_advisor_app/Dockerfile
@@ -1,5 +1,9 @@
 # Stage 1: build the vite application
-FROM node:20-alpine AS build
+# Build on the native builder arch ($BUILDPLATFORM). The Vite output (dist/) is
+# static files and architecture-independent, so cross-compiling to a different
+# target platform never runs esbuild under emulation (which crashes with
+# "The service was stopped" when amd64 is emulated on arm64 builders).
+FROM --platform=$BUILDPLATFORM node:20-alpine AS build
 
 # Accept build-time arguments
 ARG LIF_ADVISOR_API_URL

--- a/frontends/lif_advisor_app/build-push.sh
+++ b/frontends/lif_advisor_app/build-push.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Build and push the LIF Advisor App image for a target environment.
+#
+# The advisor-app is a Vite SPA: its API base URL (VITE_LIF_ADVISOR_API_URL) is
+# baked into the JS bundle at BUILD time (see Dockerfile), so the image is
+# environment-specific and CANNOT be promoted dev->demo like the backend
+# services. Build a dedicated image per environment with this script.
+#
+# CI (.github/workflows/lif_advisor_app.yml) builds the dev image automatically.
+# The dev CI role can push only to lif/dev/*, so the demo image must be built
+# here with admin/SSO creds during the manual demo promotion.
+#
+# Usage:
+#   ./build-push.sh <dev|demo> [tag]
+#
+# Then point cloudformation/<env>-lif-advisor-app.params ImageUrl at the pushed
+# tag and run aws-deploy for the <env> advisor-app stack.
+
+set -euo pipefail
+
+ENVIRONMENT="${1:?usage: build-push.sh <dev|demo> [tag]}"
+REGION="${AWS_REGION:-us-east-1}"
+ACCOUNT="${AWS_ACCOUNT_ID:-381492161417}"
+GA_MEASUREMENT_ID="${GA_MEASUREMENT_ID:-G-WCYGBK4XHK}"
+
+case "$ENVIRONMENT" in
+  dev)  API_URL="https://advisor-api.dev.lif.unicon.net" ;;
+  demo) API_URL="https://advisor-api.demo.lif.unicon.net" ;;
+  *) echo "unknown environment: $ENVIRONMENT (expected dev|demo)" >&2; exit 1 ;;
+esac
+
+REPO="lif/${ENVIRONMENT}/lif_advisor_app"
+REGISTRY="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com"
+TAG="${2:-$(date +%Y-%m-%d-%H-%M-%S)-$(git rev-parse --short HEAD)}"
+
+cd "$(dirname "$0")"
+
+echo "Building advisor-app for '${ENVIRONMENT}'"
+echo "  API URL : ${API_URL}"
+echo "  ECR repo: ${REGISTRY}/${REPO}"
+echo "  tag     : ${TAG} (+ :latest)"
+
+aws ecr get-login-password --region "$REGION" \
+  | docker login --username AWS --password-stdin "$REGISTRY"
+
+docker build \
+  --platform linux/amd64 \
+  --build-arg "LIF_ADVISOR_API_URL=${API_URL}" \
+  --build-arg "GA_MEASUREMENT_ID=${GA_MEASUREMENT_ID}" \
+  -t "${REGISTRY}/${REPO}:${TAG}" \
+  -t "${REGISTRY}/${REPO}:latest" \
+  .
+
+docker push "${REGISTRY}/${REPO}:${TAG}"
+docker push "${REGISTRY}/${REPO}:latest"
+
+echo
+echo "Pushed ${REGISTRY}/${REPO}:${TAG} (+ :latest)"
+echo "Next: set cloudformation/${ENVIRONMENT}-lif-advisor-app.params ImageUrl to this tag, then aws-deploy the ${ENVIRONMENT} advisor-app stack."


### PR DESCRIPTION
##### Description of Change

The demo advisor chatbot pulls in no learner data. **Root cause:** the advisor-app is a Vite SPA whose API base URL is **baked into the JS bundle at build time** (`Dockerfile` → `VITE_LIF_ADVISOR_API_URL`; `axios.ts` reads `import.meta.env.VITE_LIF_ADVISOR_API_URL` as the browser's base URL). That makes the image **environment-specific** — it can't be promoted dev→demo like the backend services. The demo stack reuses the dev-built image, so the demo chatbot's browser calls `https://advisor-api.dev.lif.unicon.net`; that cross-origin call is blocked, so **no chat request ever reaches the demo backend** → no data.

Verified in CloudWatch: the demo `advisor-api` logged **zero chat POSTs in 7 days** (only bot/scanner 404s), while the demo backend itself is healthy (`/health`, `/docs` → 200) and correctly wired to demo graphql. The live demo bundle has `https://advisor-api.dev.lif.unicon.net` baked in.

**Solution** — make the build parameterized by environment and point demo at its own image:

- **`.github/workflows/lif_advisor_app.yml`** — parameterize by target environment (`workflow_dispatch` input, default `dev`): the environment selects the advisor-api URL baked in and the ECR repo. Only `dev` auto-deploys from CI (dev cluster + dev role); push events behave exactly as before.
- **`frontends/lif_advisor_app/build-push.sh`** (new) — parameterized build+push (`<dev|demo>` → API URL + `lif/<env>/lif_advisor_app`). The dev CI role can push only to `lif/dev/*`, so the **demo image is built here with admin/SSO creds during the manual promotion**.
- **`cloudformation/demo-lif-advisor-app.params`** — `ImageUrl` now points at `lif/demo/lif_advisor_app` (the repo already exists) instead of the dev-built image.
- **`cloudformation/lif-advisor-app-taskdef-includes.yml`** — documents that the runtime `LIF_ADVISOR_API_URL` is **inert** for this SPA (kept only to keep the Environment block non-empty); the URL is a build-time concern.

**Side effects / limitations:**
- CI behavior for `dev` is unchanged (still builds + deploys dev on push to `main`).
- CI **cannot** build the demo image today — `lif-github-actions-policy-dev` grants ECR push only to `lif/dev/*` (verified). Demo images are built via `build-push.sh` with admin creds during promotion. *Optional follow-up if you'd prefer CI to own it: grant that role push to `lif/demo/lif_advisor_app`, after which dispatching the workflow with `environment=demo` would work end-to-end.*
- Demo `ImageUrl` is set to `:latest`; the promotion can pin the produced date-sha tag if you want reproducibility (matches how backend demo params pin tags).

**How to test / roll out:**
1. `cd frontends/lif_advisor_app && ./build-push.sh demo` (with admin creds).
2. `aws-deploy.sh -s demo --only-stack demo-lif-advisor-app`.
3. Load `https://advisor.demo.lif.unicon.net`, ask the chatbot something; confirm the request hits `advisor-api.demo…` and data comes back. (Verify the baked URL in the served bundle is `advisor-api.demo.lif.unicon.net`.)

##### Related Issues

Closes #1047

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] frontends/
- [x] cloudformation/ or sam/ templates
- [x] scripts/ (build-push.sh)
- [ ] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)

---

> **Related (separate PR):** `mdr-frontend` is also a Vite SPA with the same baked-config pattern (`VITE_API_URL`, `VITE_COGNITO_DOMAIN`, `VITE_COGNITO_CLIENT_ID`) — filed separately; not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)