### PR TITLE
Issue #1050: Parameterize ALB idle timeout (default 150s) to fix demo advisor 504s

### DIFF
--- a/cloudformation/service-common.yml
+++ b/cloudformation/service-common.yml
@@ -68,6 +68,15 @@ Parameters:
       - internet-facing
       - internal
 
+  LoadBalancerIdleTimeoutSeconds:
+    Type: String
+    Description: >-
+      ALB idle timeout (seconds). Must exceed the slowest synchronous response
+      served through this load balancer. The advisor's load_profile call runs
+      ~45s (LLM + MCP + GraphQL), so the previous 30s caused ALB 504s on demo
+      (surfaced in the browser as a CORS error). See issue #1050.
+    Default: '150'
+
   DnsZone:
     Description: Route53 hosted zone to use for the database's DNS record (<prefix>.<zone>)
     Type: 'AWS::SSM::Parameter::Value<String>'
@@ -336,7 +345,7 @@ Resources:
       Scheme: !Ref LoadBalancerScheme
       LoadBalancerAttributes:
       - Key: idle_timeout.timeout_seconds
-        Value: '30'
+        Value: !Ref LoadBalancerIdleTimeoutSeconds
       - Key: access_logs.s3.enabled
         Value: 'true'
       - Key: access_logs.s3.bucket


### PR DESCRIPTION
##### Description of Change

**Problem:** on demo, the advisor chatbot fails to initialize. The browser shows a CORS error on `POST /start-conversation`, but that's a red herring — the actual failure is a **504 Gateway Timeout** from the shared demo ALB. `/start-conversation` runs the advisor's `load_profile` agent (LLM + MCP + GraphQL) for **~43s**, and the demo ALB's `idle_timeout.timeout_seconds` was **30s**, so the ALB gave up before the app responded. ALB error responses carry no CORS headers, so the browser mislabels it as CORS. Server logs confirm the request completes (~18:08:42 → 18:09:25); the client just never receives it.

`cloudformation/service-common.yml` **hardcoded** the value to `'30'`. Dev worked only because its ALB had drifted to 150s via a manual change.

**Solution:** make the idle timeout a parameter (`LoadBalancerIdleTimeoutSeconds`, default `150`) and reference it in `LoadBalancerAttributes`. This codifies the working value (no drift), keeps it tunable per stack, and — since `service-common.yml` is the shared template — brings every environment's ALB to a sane default.

- The demo ALB (`demo-l-LoadB-wRG641i3XDqq`) was already bumped to 150s via `modify-load-balancer-attributes` to unblock the demo immediately; this PR prevents the next `aws-deploy` from resetting it to 30.
- The shared demo ALB fronts advisor, advisor-api, mdr-api, graphql-org1, lde, and dagster — a longer idle timeout is safe for all of them.

**Side effects / limitations:** none functional beyond allowing idle connections to live longer. The proper app-level fix is response streaming for the advisor (proposal #970) so the reply isn't one ~43s blob; this PR is the correct infra baseline regardless.

**How to test:** deploying the LB stack sets idle timeout to 150 (verify `idle_timeout.timeout_seconds` on the ALB). On demo, the advisor now initializes instead of 504-ing.

##### Related Issues

Closes #1050

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)