### PR TITLE
Issue #1034: scaffold cognito_auth brick + composite LDE inbound auth (bare core, decorate at edges)

### DIFF
--- a/bases/lif/learner_data_export_api/core.py
+++ b/bases/lif/learner_data_export_api/core.py
@@ -1,6 +1,14 @@
+import os
+from typing import Any, Callable, Optional
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
 from lif.api_key_auth import ApiKeyAuthMiddleware, ApiKeyConfig
+from lif.cognito_auth import CognitoAuthConfig, authenticate_request
 from lif.learner_data_export_api import learner_data_export_endpoints
 from lif.logging import get_logger
 from lif.mdr_utils.config import get_settings
@@ -9,17 +17,87 @@ logger = get_logger(__name__)
 settings = get_settings()
 app = FastAPI(title="LIF Learner Data Export API", description="API for the LIF Learner Data Export", version="1.0.0")
 
-# API-key authentication for external callers (downstream applications).
-# Keys are provisioned out-of-band into LDE_AUTH__API_KEYS (SSM-backed) as
-# "key:label" pairs; auth self-disables when no keys are configured (matching
-# the GraphQL API pattern). This is the inbound credential only — LDE's own
-# outbound call to MDR uses the separate LIF_MDR_API_AUTH_TOKEN.
-auth_config = ApiKeyConfig.from_environment(prefix="LDE_AUTH")
-if auth_config.is_enabled:
-    app.add_middleware(ApiKeyAuthMiddleware, config=auth_config)
-    logger.info("API key authentication enabled for Learner Data Export (%d keys)", len(auth_config.api_keys))
+
+# --- Inbound authentication -------------------------------------------------
+# LDE is bare on `api_key_auth` by default. Per ADR 0004, richer auth is a
+# *decoration* composed here at the base, not baked into the LDE component.
+#
+# #1034 target: accept a signed developer key OR a Cognito JWT. Opt in with
+# LDE_AUTH__MODE=composite; the default ("api_key") keeps current behavior, so
+# this scaffold changes nothing at runtime until explicitly enabled.
+AuthStrategy = Callable[[Request], Optional[dict[str, Any]]]
+
+
+def _developer_key_strategy(request: Request) -> Optional[dict[str, Any]]:
+    """Validate a signed developer key (from the #1033/#1038 keys store).
+
+    TODO(#1034): implement HMAC signed-token offline verification (ADR 0002) —
+    parse the `X-API-Key` / bearer developer key, verify signature + expiry +
+    revocation, return {owner, workspace, key_id}. Stub returns None until the
+    signed-token format lands with #1038, so composite mode currently
+    authenticates via Cognito only.
+    """
+    return None
+
+
+class CompositeAuthMiddleware(BaseHTTPMiddleware):
+    """Try each auth strategy in order; first to return a principal wins, else 401.
+
+    Composition glue (a base concern), not a reusable component — it wires
+    together single-purpose auth bricks (`cognito_auth`, and later the developer
+    signed-key validator).
+    """
+
+    def __init__(
+        self, app, strategies: list[tuple[str, AuthStrategy]], public_paths=None, public_prefixes=None
+    ) -> None:
+        super().__init__(app)
+        self.strategies = strategies
+        self.public_paths = public_paths or {"/health", "/health-check"}
+        self.public_prefixes = public_prefixes or {"/docs", "/openapi.json"}
+
+    def _is_public(self, path: str) -> bool:
+        return path in self.public_paths or any(path.startswith(p) for p in self.public_prefixes)
+
+    async def dispatch(self, request: Request, call_next):
+        if self._is_public(request.url.path):
+            return await call_next(request)
+        for name, strategy in self.strategies:
+            principal = strategy(request)
+            if principal is not None:
+                request.state.auth_method = name
+                request.state.principal = principal
+                return await call_next(request)
+        return JSONResponse(status_code=401, content={"detail": "Missing or invalid credentials"})
+
+
+_auth_mode = os.environ.get("LDE_AUTH__MODE", "api_key")
+if _auth_mode == "composite":
+    # #1034 scaffold: signed developer key OR Cognito JWT, composed from bricks.
+    cognito_config = CognitoAuthConfig.from_environment(prefix="LDE_AUTH")
+    strategies: list[tuple[str, AuthStrategy]] = [
+        ("developer_key", _developer_key_strategy),
+        ("cognito", lambda r: authenticate_request(r, cognito_config)),
+    ]
+    app.add_middleware(CompositeAuthMiddleware, strategies=strategies)
+    logger.info(
+        "LDE composite auth enabled (developer-key [TODO #1034] or Cognito JWT; cognito pool configured=%s)",
+        cognito_config.is_enabled,
+    )
 else:
-    logger.warning("API key authentication NOT configured (LDE_AUTH__API_KEYS unset) — endpoints are unauthenticated")
+    # Default / bare: API-key auth for downstream applications. Keys are
+    # provisioned out-of-band into LDE_AUTH__API_KEYS (SSM-backed) as "key:label"
+    # pairs; auth self-disables when no keys are configured (matching GraphQL).
+    # This is the inbound credential only — LDE's outbound call to MDR uses the
+    # separate LIF_MDR_API_AUTH_TOKEN.
+    auth_config = ApiKeyConfig.from_environment(prefix="LDE_AUTH")
+    if auth_config.is_enabled:
+        app.add_middleware(ApiKeyAuthMiddleware, config=auth_config)
+        logger.info("API key authentication enabled for Learner Data Export (%d keys)", len(auth_config.api_keys))
+    else:
+        logger.warning(
+            "API key authentication NOT configured (LDE_AUTH__API_KEYS unset) — endpoints are unauthenticated"
+        )
 # Configure CORS middleware
 cors_origins = [origin.strip() for origin in settings.cors_allow_origins.split(",") if origin.strip()]
 cors_methods = [method.strip() for method in settings.cors_allow_methods.split(",") if method.strip()]

--- a/components/lif/cognito_auth/README.md
+++ b/components/lif/cognito_auth/README.md
@@ -1,0 +1,33 @@
+# cognito_auth
+
+Reusable **Cognito JWT** authentication — a single-purpose decoration brick
+(ADR 0004). It validates that a request carries a valid Cognito access/ID token
+from the configured user pool and exposes the claims; it carries **no** MDR,
+tenant, or LDE concerns.
+
+## Why a separate brick
+
+`mdr_auth` bundles Cognito validation with MDR tenant routing and service keys.
+`cognito_auth` extracts just the Cognito piece, configured per-service, so any
+service (LDE, others) can compose it without pulling in MDR. This is the pattern
+in ADR 0004: bare capability in a component, composed at the edges.
+
+## Public surface
+
+- `CognitoAuthConfig` — `from_environment(prefix="COGNITO_AUTH")`; reads
+  `{PREFIX}__USER_POOL_ID` / `__REGION` / `__CLIENT_ID`. `is_enabled` is false
+  when no pool is set, so a bare deployment runs without Cognito.
+- `decode_cognito_jwt(token, config)` — verify + decode (raises on invalid).
+- `authenticate_request(request, config) -> claims | None` — the composable
+  **strategy**: returns claims for a valid Bearer JWT, else `None` (never raises),
+  so a composite can fall through to another strategy.
+- `CognitoAuthMiddleware` — optional standalone Cognito-only middleware.
+
+## Composition (the LDE case, #1034)
+
+LDE stays **bare on `api_key_auth`** by default. When developer keys + Cognito are
+enabled, the LDE base composes a *composite* inbound middleware that accepts a
+**signed developer key OR a Cognito JWT** — calling `authenticate_request` here as
+the JWT strategy and the developer-key validator (signed-token offline verify,
+#1033/#1038, ADR 0002) as the other. The composite lives at the base (composition
+is a base concern); this brick just provides the Cognito strategy.

--- a/components/lif/cognito_auth/__init__.py
+++ b/components/lif/cognito_auth/__init__.py
@@ -1,0 +1,3 @@
+from lif.cognito_auth.core import CognitoAuthConfig, CognitoAuthMiddleware, authenticate_request, decode_cognito_jwt
+
+__all__ = ["CognitoAuthConfig", "CognitoAuthMiddleware", "authenticate_request", "decode_cognito_jwt"]

--- a/components/lif/cognito_auth/core.py
+++ b/components/lif/cognito_auth/core.py
@@ -1,0 +1,150 @@
+"""Reusable Cognito JWT authentication — a single-purpose *decoration* brick.
+
+Per ADR 0004, this is bare capability: an MDR-/tenant-/LDE-independent validator
+that answers only "is this a valid Cognito JWT from the configured user pool, and
+who is it?" Any service can compose it. The Cognito-verification logic is ported
+from `mdr_auth`, decoupled from MDR settings so it is configured per-service via
+`CognitoAuthConfig.from_environment(prefix=...)` (mirroring `api_key_auth`). See #1034.
+
+Public surface:
+- ``CognitoAuthConfig`` — per-service config (from env).
+- ``decode_cognito_jwt(token, config)`` — verify + decode (raises on invalid).
+- ``authenticate_request(request, config)`` — extract Bearer + decode; returns
+  the claims dict or ``None``. This is the composable *strategy* a composite
+  middleware calls (e.g. the LDE "signed key OR Cognito JWT" dispatch).
+- ``CognitoAuthMiddleware`` — optional standalone middleware for Cognito-only services.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import jwt
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+_BEARER_PREFIX = "Bearer "
+
+# Cache PyJWKClient per (region, pool) so JWKS keys are fetched once per process.
+_jwk_clients: dict[tuple[str, str], jwt.PyJWKClient] = {}
+
+
+@dataclass
+class CognitoAuthConfig:
+    """Cognito validation config for one service."""
+
+    user_pool_id: str = ""
+    region: str = "us-east-1"
+    client_id: str = ""
+    public_paths: set[str] = field(default_factory=lambda: {"/health", "/health-check"})
+    public_path_prefixes: set[str] = field(default_factory=lambda: {"/docs", "/openapi.json"})
+
+    @property
+    def is_enabled(self) -> bool:
+        """Cognito auth is active only when a user pool is configured."""
+        return bool(self.user_pool_id)
+
+    @property
+    def issuer(self) -> str:
+        return f"https://cognito-idp.{self.region}.amazonaws.com/{self.user_pool_id}"
+
+    @property
+    def jwks_url(self) -> str:
+        return f"{self.issuer}/.well-known/jwks.json"
+
+    @classmethod
+    def from_environment(cls, prefix: str = "COGNITO_AUTH") -> "CognitoAuthConfig":
+        """Load config from ``{PREFIX}__USER_POOL_ID`` / ``__REGION`` / ``__CLIENT_ID``.
+
+        Auth self-disables when ``USER_POOL_ID`` is unset (matching the
+        ``api_key_auth`` "no keys → disabled" pattern), so a bare deployment
+        runs without Cognito.
+        """
+        return cls(
+            user_pool_id=os.environ.get(f"{prefix}__USER_POOL_ID", ""),
+            region=os.environ.get(f"{prefix}__REGION", "us-east-1"),
+            client_id=os.environ.get(f"{prefix}__CLIENT_ID", ""),
+        )
+
+
+def _get_jwk_client(config: CognitoAuthConfig) -> jwt.PyJWKClient:
+    key = (config.region, config.user_pool_id)
+    if key not in _jwk_clients:
+        _jwk_clients[key] = jwt.PyJWKClient(config.jwks_url, cache_keys=True, lifespan=3600)
+    return _jwk_clients[key]
+
+
+def decode_cognito_jwt(token: str, config: CognitoAuthConfig) -> dict[str, Any]:
+    """Verify + decode a Cognito JWT (RS256/JWKS). Raises ``jwt.PyJWTError`` on invalid.
+
+    Validates signature, issuer, and that the token belongs to the configured
+    client (``aud`` for ID tokens, ``client_id`` for access tokens).
+    """
+    signing_key = _get_jwk_client(config).get_signing_key_from_jwt(token)
+    payload = jwt.decode(
+        token,
+        signing_key.key,
+        algorithms=["RS256"],
+        issuer=config.issuer,
+        options={"verify_aud": False},  # Cognito access tokens carry client_id, not aud
+    )
+    token_use = payload.get("token_use")
+    if token_use == "id":
+        if config.client_id and payload.get("aud") != config.client_id:
+            raise jwt.InvalidTokenError("ID token audience does not match client ID")
+    elif token_use == "access":
+        if config.client_id and payload.get("client_id") != config.client_id:
+            raise jwt.InvalidTokenError("Access token client_id does not match client ID")
+    else:
+        raise jwt.InvalidTokenError(f"Unexpected token_use: {token_use}")
+    return payload
+
+
+def _extract_bearer(request: Request) -> Optional[str]:
+    header = request.headers.get("Authorization", "")
+    if header.startswith(_BEARER_PREFIX):
+        return header[len(_BEARER_PREFIX) :].strip() or None
+    return None
+
+
+def authenticate_request(request: Request, config: CognitoAuthConfig) -> Optional[dict[str, Any]]:
+    """Composable strategy: return the Cognito claims for a valid Bearer JWT, else ``None``.
+
+    Never raises — a composite (e.g. LDE's "signed key OR Cognito JWT" dispatch)
+    calls this and falls through to the next strategy on ``None``.
+    """
+    token = _extract_bearer(request)
+    if not token:
+        return None
+    try:
+        return decode_cognito_jwt(token, config)
+    except jwt.PyJWTError:
+        return None
+
+
+class CognitoAuthMiddleware(BaseHTTPMiddleware):
+    """Standalone Cognito-only middleware for services that want just Cognito.
+
+    Services needing "Cognito JWT *or* something else" should compose
+    ``authenticate_request`` in a composite instead (see the LDE base).
+    """
+
+    def __init__(self, app, config: CognitoAuthConfig) -> None:
+        super().__init__(app)
+        self.config = config
+
+    def _is_public(self, path: str) -> bool:
+        return path in self.config.public_paths or any(path.startswith(p) for p in self.config.public_path_prefixes)
+
+    async def dispatch(self, request: Request, call_next):
+        if self._is_public(request.url.path):
+            return await call_next(request)
+        claims = authenticate_request(request, self.config)
+        if claims is None:
+            return JSONResponse(status_code=401, content={"detail": "Invalid or missing Cognito token"})
+        request.state.cognito_claims = claims
+        request.state.cognito_sub = claims.get("sub")
+        return await call_next(request)

--- a/projects/lif_learner_data_export_api/pyproject.toml
+++ b/projects/lif_learner_data_export_api/pyproject.toml
@@ -35,6 +35,7 @@ packages = ["lif"]
 "../../components/lif/datatypes" = "lif/datatypes"             # direct use
 "../../components/lif/mdr_utils" = "lif/mdr_utils"             # direct use
 "../../components/lif/api_key_auth" = "lif/api_key_auth"       # direct use (ApiKeyAuthMiddleware)
+"../../components/lif/cognito_auth" = "lif/cognito_auth"       # direct use (composite auth scaffold, #1034)
 "../../components/lif/mdr_dto" = "lif/mdr_dto"                 # via datatypes.mdr_consumer
 "../../components/lif/lif_schema_config" = "lif/lif_schema_config" # direct use
 "../../components/lif/mdr_client" = "lif/mdr_client"           # direct use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ asyncio_mode = "auto"
 "components/lif/mdr_dto" = "lif/mdr_dto"
 "components/lif/query_planner_client" = "lif/query_planner_client"
 "components/lif/translator_client" = "lif/translator_client"
+"components/lif/cognito_auth" = "lif/cognito_auth"
 
 [tool.ruff]
 line-length = 120

--- a/test/components/lif/cognito_auth/test_core.py
+++ b/test/components/lif/cognito_auth/test_core.py
@@ -1,0 +1,51 @@
+# cspell:disable
+import jwt
+from starlette.requests import Request
+
+import lif.cognito_auth.core as core
+from lif.cognito_auth import CognitoAuthConfig, authenticate_request
+
+
+def _req(authorization=None):
+    headers = []
+    if authorization is not None:
+        headers.append((b"authorization", authorization.encode()))
+    return Request({"type": "http", "method": "GET", "path": "/exports", "headers": headers})
+
+
+def test_from_environment_reads_prefixed_vars(monkeypatch):
+    monkeypatch.setenv("LDE_AUTH__USER_POOL_ID", "us-east-1_ABC123")
+    monkeypatch.setenv("LDE_AUTH__REGION", "us-east-1")
+    monkeypatch.setenv("LDE_AUTH__CLIENT_ID", "client-xyz")
+    cfg = CognitoAuthConfig.from_environment(prefix="LDE_AUTH")
+    assert cfg.is_enabled
+    assert cfg.user_pool_id == "us-east-1_ABC123"
+    assert cfg.issuer == "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_ABC123"
+    assert cfg.jwks_url.endswith("/.well-known/jwks.json")
+
+
+def test_disabled_when_no_pool(monkeypatch):
+    monkeypatch.delenv("LDE_AUTH__USER_POOL_ID", raising=False)
+    assert not CognitoAuthConfig.from_environment(prefix="LDE_AUTH").is_enabled
+
+
+def test_authenticate_returns_none_without_bearer():
+    cfg = CognitoAuthConfig(user_pool_id="us-east-1_ABC")
+    assert authenticate_request(_req(), cfg) is None
+    assert authenticate_request(_req("Basic zzz"), cfg) is None
+
+
+def test_authenticate_returns_claims_for_valid_token(monkeypatch):
+    cfg = CognitoAuthConfig(user_pool_id="us-east-1_ABC")
+    monkeypatch.setattr(core, "decode_cognito_jwt", lambda token, config: {"sub": "user-1", "token_use": "access"})
+    assert authenticate_request(_req("Bearer good.token"), cfg) == {"sub": "user-1", "token_use": "access"}
+
+
+def test_authenticate_returns_none_for_invalid_token(monkeypatch):
+    cfg = CognitoAuthConfig(user_pool_id="us-east-1_ABC")
+
+    def boom(token, config):
+        raise jwt.InvalidTokenError("bad")
+
+    monkeypatch.setattr(core, "decode_cognito_jwt", boom)
+    assert authenticate_request(_req("Bearer bad.token"), cfg) is None


### PR DESCRIPTION
##### Description of Change

Scaffolds LDE's move beyond a static API token, built to match **ADR 0004** (bare core, decorate at the edges): the LDE service stays bare on `api_key_auth`; richer auth is *composed at the base*, not baked into the component.

- **`components/lif/cognito_auth`** (new brick) — a reusable, single-purpose Cognito JWT validator: `CognitoAuthConfig.from_environment(prefix=…)`, `decode_cognito_jwt`, `authenticate_request` (the composable strategy), and an optional standalone `CognitoAuthMiddleware`. The Cognito/JWKS logic is ported from `mdr_auth` but **decoupled from MDR/tenant settings**, so any service can compose it without pulling in MDR (the ADR 0002 / ADR 0004 point).
- **`bases/lif/learner_data_export_api`** — `CompositeAuthMiddleware` (base-level composition glue) that tries a signed-developer-key strategy, then the Cognito strategy. **Opt in via `LDE_AUTH__MODE=composite`; the default `api_key` keeps current behavior unchanged**, so nothing changes at runtime (demo/dev unaffected) until explicitly enabled.
- Brick registered (root + LDE project `pyproject.toml`); tests cover config parsing and the Cognito strategy (decode monkeypatched — no live JWKS).

**Scaffold scope:** Cognito verification is real; the **developer signed-key strategy is a documented stub** (`_developer_key_strategy`) pending the signed-token format that lands with the keys store (#1033/#1038) + HMAC offline verify (ADR 0002). Composite mode currently authenticates via Cognito only.

**How to test:** default (`LDE_AUTH__MODE` unset) → unchanged api_key behavior; `LDE_AUTH__MODE=composite` + `LDE_AUTH__USER_POOL_ID/REGION/CLIENT_ID` → Cognito JWTs accepted. `uv run pytest test/components/lif/cognito_auth`.

##### Related Issues

Part of #1000 (#1034). Depends on #1038 (developer-keys store) for the signed-key path. Embodies ADR 0004 (#1058); relates to ADR 0002 (#1041).

##### Type of Change

- [x] New feature (non-breaking change which adds functionality)

##### Project Area(s) Affected

- [x] bases/
- [x] components/
- [x] test/ or e2e/
- [x] API endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)