### PR TITLE
Issue #1036: LDE test/export playground UI (persona picker + colorized viewer)

### DIFF
--- a/.github/workflows/lif_mdr_frontend.yml
+++ b/.github/workflows/lif_mdr_frontend.yml
@@ -52,6 +52,7 @@ jobs:
         echo "VITE_GA_MEASUREMENT_ID=G-VZ515ZL70E" >> .env
         echo "VITE_COGNITO_DOMAIN=${cognito_domain}" >> .env
         echo "VITE_COGNITO_CLIENT_ID=${cognito_client_id}" >> .env
+        echo "VITE_LDE_API_URL=https://lde.${{ env.ENV_NAME }}.${{ env.DOMAIN }}" >> .env
         npm run build
 
     - name: Sync to S3

--- a/frontends/mdr-frontend/Dockerfile
+++ b/frontends/mdr-frontend/Dockerfile
@@ -10,6 +10,8 @@ ARG COGNITO_DOMAIN
 ENV COGNITO_DOMAIN=${COGNITO_DOMAIN}
 ARG COGNITO_CLIENT_ID
 ENV COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}
+ARG LDE_API_URL
+ENV LDE_API_URL=${LDE_API_URL}
 
 # Set working directory
 WORKDIR /app
@@ -26,6 +28,7 @@ RUN echo "VITE_API_URL=${LIF_MDR_API_URL}" > .env && \
     echo "VITE_GA_MEASUREMENT_ID=${GA_MEASUREMENT_ID}" >> .env && \
     echo "VITE_COGNITO_DOMAIN=${COGNITO_DOMAIN}" >> .env && \
     echo "VITE_COGNITO_CLIENT_ID=${COGNITO_CLIENT_ID}" >> .env && \
+    echo "VITE_LDE_API_URL=${LDE_API_URL}" >> .env && \
     npm run build
 
 # Stage 2: serve the built app with nginx

--- a/frontends/mdr-frontend/src/components/Header/Header.tsx
+++ b/frontends/mdr-frontend/src/components/Header/Header.tsx
@@ -87,6 +87,12 @@ const Header: React.FC = () => {
           >
             API Keys
           </NavLink>
+          <NavLink
+            to="/export-playground"
+            className={({ isActive }) => (isActive ? "active" : "")}
+          >
+            Export Playground
+          </NavLink>
         </nav>
 
         {/* User dropdown sits in its natural left-packed position right

--- a/frontends/mdr-frontend/src/components/JsonHighlight/JsonHighlight.css
+++ b/frontends/mdr-frontend/src/components/JsonHighlight/JsonHighlight.css
@@ -1,0 +1,31 @@
+.json-highlight {
+  margin: 0;
+  padding: var(--space-3);
+  overflow-x: auto;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--gray-2);
+  border: 1px solid var(--gray-5);
+  border-radius: var(--radius-3);
+  font-family: var(--code-font-family, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre;
+  tab-size: 2;
+}
+
+.json-highlight .tok-key {
+  color: var(--accent-11);
+}
+.json-highlight .tok-str {
+  color: var(--green-11);
+}
+.json-highlight .tok-num {
+  color: var(--blue-11);
+}
+.json-highlight .tok-bool {
+  color: var(--purple-11);
+}
+.json-highlight .tok-null {
+  color: var(--gray-10);
+}

--- a/frontends/mdr-frontend/src/components/JsonHighlight/JsonHighlight.tsx
+++ b/frontends/mdr-frontend/src/components/JsonHighlight/JsonHighlight.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import "./JsonHighlight.css";
+
+// Dependency-free JSON syntax highlighting. The export payload is untrusted, so
+// HTML is escaped first, then tokens are wrapped in themed spans. Avoids a
+// syntax-highlighter dependency and keeps the (CSP-strict) bundle self-contained.
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+const TOKEN = /("(?:\\u[a-fA-F0-9]{4}|\\[^u]|[^\\"])*"(?:\s*:)?|\b(?:true|false|null)\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+function highlight(json: string): string {
+  return escapeHtml(json).replace(TOKEN, (match) => {
+    let cls = "tok-num";
+    if (match.startsWith('"')) {
+      cls = match.trimEnd().endsWith(":") ? "tok-key" : "tok-str";
+    } else if (match === "true" || match === "false") {
+      cls = "tok-bool";
+    } else if (match === "null") {
+      cls = "tok-null";
+    }
+    return `<span class="${cls}">${match}</span>`;
+  });
+}
+
+/** Pretty-print + colorize a value as JSON. */
+export default function JsonHighlight({ value }: { value: unknown }) {
+  const html = useMemo(() => highlight(JSON.stringify(value, null, 2)), [value]);
+  return (
+    <pre className="json-highlight">
+      <code dangerouslySetInnerHTML={{ __html: html }} />
+    </pre>
+  );
+}

--- a/frontends/mdr-frontend/src/pages/ExportPlayground.tsx
+++ b/frontends/mdr-frontend/src/pages/ExportPlayground.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from "react";
+import { Box, Button, Callout, Card, Container, Flex, Heading, IconButton, Select, Spinner, Text } from "@radix-ui/themes";
+import { CheckIcon, CopyIcon, InfoCircledIcon, PlayIcon } from "@radix-ui/react-icons";
+import exportService, { DataFormat } from "../services/exportService";
+import personasService, { Persona } from "../services/personasService";
+import JsonHighlight from "../components/JsonHighlight/JsonHighlight";
+import { useToast } from "../context/ToastContext";
+
+function errorMessage(err: unknown, fallback: string): string {
+  const e = err as { response?: { data?: { detail?: string } }; message?: string };
+  return e?.response?.data?.detail || e?.message || fallback;
+}
+
+export default function ExportPlayground() {
+  const { showToast } = useToast();
+
+  const [personas, setPersonas] = useState<Persona[]>([]);
+  const [formats, setFormats] = useState<DataFormat[]>([]);
+  const [loadingMeta, setLoadingMeta] = useState(true);
+  const [metaError, setMetaError] = useState<string | null>(null);
+
+  const [learnerId, setLearnerId] = useState("");
+  const [formatIdx, setFormatIdx] = useState("");
+
+  const [output, setOutput] = useState<unknown>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      setLoadingMeta(true);
+      const [personaResult, formatResult] = await Promise.allSettled([
+        personasService.getPersonas(),
+        exportService.getAvailableDataFormats(),
+      ]);
+      if (!active) return;
+      const errors: string[] = [];
+      if (personaResult.status === "fulfilled") setPersonas(personaResult.value);
+      else errors.push("test learners");
+      if (formatResult.status === "fulfilled") setFormats(formatResult.value.DataFormats ?? []);
+      else errors.push("data formats");
+      setMetaError(errors.length ? `Could not load ${errors.join(" or ")}. Check that you're signed in and the services are reachable.` : null);
+      setLoadingMeta(false);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const selectedFormat = formatIdx === "" ? undefined : formats[Number(formatIdx)];
+  const canSubmit = Boolean(learnerId) && Boolean(selectedFormat) && !submitting;
+
+  const handleSubmit = async () => {
+    if (!learnerId || !selectedFormat) return;
+    setSubmitting(true);
+    setExportError(null);
+    setOutput(null);
+    try {
+      const data = await exportService.runExport({
+        learnerId,
+        dataModelName: selectedFormat.name,
+        dataModelVersion: selectedFormat.version,
+        dataModelContributorOrganization: selectedFormat.contributorOrganization,
+      });
+      setOutput(data);
+    } catch (err) {
+      setExportError(errorMessage(err, "Export failed."));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(output, null, 2));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      showToast("Copy failed — the output is still selectable", "error");
+    }
+  };
+
+  return (
+    <Container size="3" py="5">
+      <Heading size="6" mb="1">
+        Export Playground
+      </Heading>
+      <Text as="p" color="gray" mb="4">
+        Try the Learner Data Export API: pick a test learner and an output format, then run the export.
+      </Text>
+
+      <Card mb="4">
+        <Flex direction="column" gap="3" p="2">
+          <Box>
+            <Text as="label" size="2" weight="bold" mb="1" style={{ display: "block" }}>
+              Test learner
+            </Text>
+            <Select.Root value={learnerId} onValueChange={setLearnerId} disabled={loadingMeta || personas.length === 0}>
+              <Select.Trigger placeholder="Select a test learner" />
+              <Select.Content>
+                {personas.map((p) => (
+                  <Select.Item key={p.identifier} value={p.identifier}>
+                    {p.firstname} {p.lastname} ({p.identifier})
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Box>
+
+          <Box>
+            <Text as="label" size="2" weight="bold" mb="1" style={{ display: "block" }}>
+              Output format
+            </Text>
+            <Select.Root value={formatIdx} onValueChange={setFormatIdx} disabled={loadingMeta || formats.length === 0}>
+              <Select.Trigger placeholder="Select an output format" />
+              <Select.Content>
+                {formats.map((f, i) => (
+                  <Select.Item key={`${f.name}-${f.version}-${f.contributorOrganization}`} value={String(i)}>
+                    {f.name} v{f.version} — {f.contributorOrganization}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+          </Box>
+
+          <Flex align="center" gap="3">
+            <Button onClick={handleSubmit} disabled={!canSubmit}>
+              {submitting ? <Spinner /> : <PlayIcon />} Run export
+            </Button>
+            {loadingMeta && (
+              <Text size="2" color="gray">
+                <Spinner /> Loading learners and formats…
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+      </Card>
+
+      {metaError && (
+        <Callout.Root color="amber" mb="4">
+          <Callout.Icon>
+            <InfoCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>{metaError}</Callout.Text>
+        </Callout.Root>
+      )}
+
+      {exportError && (
+        <Callout.Root color="red" mb="4">
+          <Callout.Icon>
+            <InfoCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>{exportError}</Callout.Text>
+        </Callout.Root>
+      )}
+
+      {output !== null && !submitting && (
+        <Card>
+          <Flex justify="between" align="center" mb="2">
+            <Text size="2" weight="bold">
+              Result
+            </Text>
+            <IconButton variant="soft" onClick={handleCopy} aria-label="Copy result">
+              {copied ? <CheckIcon /> : <CopyIcon />}
+            </IconButton>
+          </Flex>
+          <JsonHighlight value={output} />
+        </Card>
+      )}
+    </Container>
+  );
+}

--- a/frontends/mdr-frontend/src/pages/Routes.tsx
+++ b/frontends/mdr-frontend/src/pages/Routes.tsx
@@ -9,6 +9,7 @@ import Login from "../pages/Login";
 import AuthCallback from "../pages/AuthCallback";
 import Workspaces from "../pages/Workspaces";
 import ApiKeys from "../pages/ApiKeys";
+import ExportPlayground from "../pages/ExportPlayground";
 import InviteAccept from "../pages/InviteAccept";
 import AuthGuard from "../components/AuthGuard";
 import LifModel from "./Explore/lif-model";
@@ -51,6 +52,12 @@ const routes: RouteObject[] = [
         path: "api-keys",
         element: <ApiKeys />,
         handle: { name: "API Keys" },
+      },
+      {
+        // Interactive LDE /exports playground: pick a test learner + format (#1036).
+        path: "export-playground",
+        element: <ExportPlayground />,
+        handle: { name: "Export Playground" },
       },
       {
         path: "explore",

--- a/frontends/mdr-frontend/src/services/exportService.ts
+++ b/frontends/mdr-frontend/src/services/exportService.ts
@@ -1,0 +1,45 @@
+import ldeApi from "./ldeApi";
+
+/** One selectable target data format from LDE `/available-data-formats`. */
+export interface DataFormat {
+  name: string;
+  version: string;
+  contributorOrganization: string;
+  TransformationVersions: string[];
+}
+
+export interface AvailableDataFormats {
+  metadata: Record<string, unknown>;
+  DataFormats: DataFormat[];
+}
+
+export interface ExportParams {
+  learnerId: string;
+  dataModelName: string;
+  dataModelVersion: string;
+  dataModelContributorOrganization: string;
+}
+
+class ExportService {
+  /** List the target data formats this deployment can export to. */
+  async getAvailableDataFormats(): Promise<AvailableDataFormats> {
+    const response = await ldeApi.get<AvailableDataFormats>("/available-data-formats");
+    return response.data;
+  }
+
+  /** Export a learner's data in the selected format. Returns the raw document
+   * (LDE `/exports` responds with a format-dependent JSON object). */
+  async runExport(params: ExportParams): Promise<unknown> {
+    const response = await ldeApi.get<unknown>("/exports", {
+      params: {
+        learnerId: params.learnerId,
+        dataModelName: params.dataModelName,
+        dataModelVersion: params.dataModelVersion,
+        dataModelContributorOrganization: params.dataModelContributorOrganization,
+      },
+    });
+    return response.data;
+  }
+}
+
+export default new ExportService();

--- a/frontends/mdr-frontend/src/services/ldeApi.ts
+++ b/frontends/mdr-frontend/src/services/ldeApi.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+import authService from "./authService";
+
+// The Learner Data Export (LDE) service is a separate host from the MDR API, so
+// the export playground talks to it through its own axios instance. Auth is the
+// signed-in user's Cognito access token — LDE accepts a Cognito JWT via its
+// composite inbound auth (#1034). Requires VITE_LDE_API_URL at build time and
+// LDE CORS to allow this frontend's origin.
+const ldeApi = axios.create({
+  baseURL: import.meta.env.VITE_LDE_API_URL,
+  withCredentials: true,
+});
+
+ldeApi.interceptors.request.use((config) => {
+  const token = authService.getAccessToken();
+  if (token) {
+    config.headers["Authorization"] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default ldeApi;

--- a/frontends/mdr-frontend/src/services/personasService.ts
+++ b/frontends/mdr-frontend/src/services/personasService.ts
@@ -1,0 +1,27 @@
+import api from "./api";
+
+/** A curated demo learner, served from the shared demo-persona source (#1055). */
+export interface Persona {
+  username: string;
+  firstname: string;
+  lastname: string;
+  identifier: string;
+  identifier_type: string;
+  identifier_type_enum: string;
+}
+
+class PersonasService {
+  /** Fetch the curated demo learners.
+   *
+   * Served from the shared `demo_personas` brick (#1055) via `GET /demo/personas`
+   * on the MDR API — the single source that the Advisor app also uses, so the
+   * playground's picker can't drift. (Endpoint is the browser-delivery companion
+   * to #1055.)
+   */
+  async getPersonas(): Promise<Persona[]> {
+    const response = await api.get<Persona[]>("/demo/personas");
+    return response.data;
+  }
+}
+
+export default new PersonasService();


### PR DESCRIPTION
##### Description of Change

The "test page" half of the LDE self-serve experience: a signed-in user picks a **test learner** and an **output format**, runs a live `GET /exports`, and sees the result in a **colorized JSON viewer**. Follows ADR 0004 — the frontend *composes* the LDE capability; nothing LDE-specific leaks into shared code.

- **`pages/ExportPlayground.tsx`** — persona + format selectors, run button, result viewer, loading/empty/error states (Radix; mirrors the API Keys page).
- **`services/exportService.ts` + `ldeApi.ts`** — `GET /available-data-formats` and `GET /exports` against the LDE host (`VITE_LDE_API_URL`), authed with the Cognito access token (LDE composite auth, #1034).
- **`services/personasService.ts`** — `GET /demo/personas`, the **shared** demo-persona source (#1055) the Advisor also uses, so the picker mirrors the Advisor's six and can't drift.
- **`components/JsonHighlight`** — dependency-free, CSP-safe colorized JSON (no new npm dep).
- Route + nav wiring; `VITE_LDE_API_URL` added to the Dockerfile + CI (baked per the current SPA pattern — tracked for a runtime fix in #1049).

**Verification:** `tsc -b` + `vite build` pass. (ESLint can't load on this branch due to the pre-#1032 `no-explicite-any` config typo; #1032 is merged to main, so this clears once rebased.)

##### ⚠️ Stacked / dependencies
- **Stacked on #1039** (API Keys page). Until #1039 merges, this PR's diff includes #1039's files — **review #1039 first**; GitHub will shrink this diff to just the playground once #1039 lands.
- Needs **#1034** (LDE accepts a Cognito JWT) and a **`GET /demo/personas`** endpoint (browser-delivery companion to #1055) deployed to function end-to-end; plus LDE CORS for this frontend's origin. The UI degrades gracefully (clear "couldn't load" states) until those exist.

##### Related Issues

Closes #1036. Part of #1000. Depends on #1034, #1055, #1039. Config caveat: #1049.

##### Type of Change

- [x] New feature (non-breaking change which adds functionality)

##### Project Area(s) Affected

- [x] frontends/
- [x] cloudformation/ or sam/ templates
- [x] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)