### PR TITLE
Defensive: id truthiness → is not None (audit follow-up to #1006)

### DIFF
--- a/components/lif/mdr_services/entity_association_service.py
+++ b/components/lif/mdr_services/entity_association_service.py
@@ -26,7 +26,9 @@ async def resolve_entity_id(
         query = query.where(DataModel.DataModelVersion == data_model_version)
     dm_result = await session.execute(query)
     data_model_id = dm_result.scalar_one_or_none()
-    if not data_model_id:
+    # `is None`, not truthiness: scalar_one_or_none() returns None only when no row exists;
+    # a real DataModel with PK 0 must not be reported as "not found" (cf. #1006 ElementId fix).
+    if data_model_id is None:
         raise HTTPException(status_code=404, detail=f"Data model '{data_model_name}' not found")
 
     # Get EntityId based on the name and DataModelId
@@ -36,7 +38,7 @@ async def resolve_entity_id(
     entity_result = await session.execute(entity_query)
     entity_id = entity_result.scalar_one_or_none()
 
-    if not entity_id:
+    if entity_id is None:
         raise HTTPException(
             status_code=404, detail=f"Entity '{entity_name}' not found in data model '{data_model_name}'"
         )

--- a/components/lif/mdr_services/transformation_service.py
+++ b/components/lif/mdr_services/transformation_service.py
@@ -1492,7 +1492,9 @@ async def get_transformations_by_path_ids(
         .where(TransformationAttribute.EntityIdPath == entity_id_path)
     )
 
-    if attribute_id:
+    # `is not None`, not truthiness: an AttributeId of 0 is a valid filter value; `if attribute_id:`
+    # would drop the filter and return transformations for ALL attributes (cf. #1006 ElementId fix).
+    if attribute_id is not None:
         query = query.where(TransformationAttribute.AttributeId == attribute_id)
 
     result = await session.execute(query)


### PR DESCRIPTION
##### Description of Change

A codebase sweep for the **#1006 bug class** — a valid id/index of `0` treated as "absent/not-found" via truthiness — turned up two live instances (both in `components/lif/mdr_services/`, neither in an in-flight PR):

- **`entity_association_service.py`** — `if not data_model_id:` / `if not entity_id:` raise **404 "not found"** for a real DataModel/Entity whose PK is `0` (`scalar_one_or_none()` returns `None` only when the row is truly absent). → `is None`.
- **`transformation_service.py`** — `if attribute_id:` drops the `AttributeId == 0` filter and returns transformations for **all** attributes instead of attribute `0`. → `is not None`.

**Severity:** both are **latent** — under autoincrement PKs a `0` id never occurs, so nothing fires today. This is defensive parity with #1006 (same theoretical profile), one-token mechanical fixes with an explanatory comment each.

**Audit outcome (for context):** the only bug class found was this one (id/PK truthiness); strings/lists/counts/offsets/`.find()` results are all correctly `is not None` / `!= -1` / `== 0`. Other instances are handled elsewhere: the `#756` file's case is folded into **#1007**; lower-severity `id-or-existing` (value_mapping) and ancestry-walk (jinja) cases are tracked in a separate issue.

##### Related Issues

Follow-up to #1006. Sibling fixes: #1007 (schema_upload), and the tracking issue for the low-severity remainder.

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

##### Project Area(s) Affected

- [x] components/

🤖 Generated with [Claude Code](https://claude.com/claude-code)