### PR TITLE
docs: fix PR template Closes line so merges auto-close issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,11 @@ Include:
 -->
 
 ##### Related Issues
-<!-- Link to related issues using #issue_number -->
+<!-- Auto-close the issue this PR resolves. The number must come directly after `#` (no space, no brackets)
+     or GitHub will NOT auto-close on merge — e.g. `Closes #123`. Use `Refs #123` for related-but-not-closed
+     issues. Delete this line if the PR closes nothing. -->
 
-Closes # [[add Github issue number]]
+Closes #
 
 
 ##### Type of Change


### PR DESCRIPTION
##### Description

The PR template shipped a `Closes #` line as `Closes # [[add Github issue number]]`. The space after `#` plus the bracket placeholder means GitHub's issue-closing parser never fires, so merged PRs left their issues open. Authors then had to close by hand — and often didn't.

Found during a backlog sweep: **#810, #833, #1033, #1035** were all still open despite their PRs having merged, purely because the auto-close keyword was malformed.

This replaces the placeholder with a clean `Closes #` and inline guidance on the exact syntax GitHub requires (number directly after `#`, no space/brackets; `Refs #` for related-but-not-closed).

##### Related Issues

<!-- meta / process fix — no single issue -->

##### Type of Change

- [x] Documentation / tooling

##### Checklist

- [x] Self-reviewed the diff
- [x] No code changes (template only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)