### PR TITLE
Issue #1076: enable LDE composite auth + MDR-UI CORS in deploy config

### DIFF
--- a/cloudformation/lif-learner-data-export-api-taskdef-includes.yml
+++ b/cloudformation/lif-learner-data-export-api-taskdef-includes.yml
@@ -23,6 +23,34 @@ Environment:
     Value: "/health,/health-check"
   - Name: LDE_AUTH__PUBLIC_PATH_PREFIXES
     Value: "/docs,/openapi.json"
+  # --- #1034/#1076: composite inbound auth. `composite` accepts a Cognito JWT
+  # (humans on the MDR-UI export playground) OR a signed developer key (downstream
+  # apps; still stubbed pending #1038). Pool + SPA client mirror the MDR self-serve
+  # Cognito, so the JWT minted by the MDR UI validates here. Same SSM keys mdr-api reads.
+  - Name: LDE_AUTH__MODE
+    Value: composite
+  - Name: LDE_AUTH__USER_POOL_ID
+    Value:
+      Fn::Sub: "{{resolve:ssm:/${EnvironmentName}/mdr/CognitoUserPoolId}}"
+  - Name: LDE_AUTH__CLIENT_ID
+    Value:
+      Fn::Sub: "{{resolve:ssm:/${EnvironmentName}/mdr/CognitoSpaClientId}}"
+  - Name: LDE_AUTH__REGION
+    Value:
+      Fn::Sub: "${AWS::Region}"
+  # --- #1076: CORS for the MDR-UI origin (mirrors mdr-api). Credentialed, so
+  # origins must be explicit — browsers reject `*` with credentials, and Starlette
+  # `allow_origins` is exact-match (no subdomain wildcards). The playground is served
+  # from the MDR UI, so `https://mdr.${PublicHostedZoneName}` is the only prod origin.
+  - Name: CORS_ALLOW_ORIGINS
+    Value:
+      Fn::Sub: "http://localhost:3000,http://localhost:5173,http://localhost:8080,https://mdr.${PublicHostedZoneName}"
+  - Name: CORS_ALLOW_CREDENTIALS
+    Value: true
+  - Name: CORS_ALLOW_METHODS
+    Value: GET,POST,PUT,DELETE,OPTIONS,PATCH
+  - Name: CORS_ALLOW_HEADERS
+    Value: "*"
 Secrets:
   - Name: LIF_MDR_API_AUTH_TOKEN
     ValueFrom:


### PR DESCRIPTION
##### Description

Deploy-config half of #1076 — turns on the already-merged (#1059) LDE composite inbound auth and MDR-UI CORS so the export playground (#1036) works end-to-end. **No application code changes**; the Cognito auth path and CORS middleware already shipped — they were just never enabled in the deployed task-def.

Added to `cloudformation/lif-learner-data-export-api-taskdef-includes.yml`:

- **`LDE_AUTH__MODE=composite`** — LDE accepts a Cognito JWT (humans on the MDR-UI playground) **or** a signed developer key (downstream apps; still stubbed pending #1038, so today this authenticates via Cognito only).
- **`LDE_AUTH__USER_POOL_ID` / `LDE_AUTH__CLIENT_ID` / `LDE_AUTH__REGION`** — resolved from the *same* SSM keys `mdr-api` reads (`/${EnvironmentName}/mdr/CognitoUserPoolId`, `.../CognitoSpaClientId`), so the JWT minted by the MDR UI's Cognito SPA client validates in LDE. No new SSM params.
- **`CORS_ALLOW_ORIGINS` (incl. `https://mdr.${PublicHostedZoneName}`) + credentials/methods/headers** — mirrors `mdr-api`. Origins are **explicit**: credentialed CORS can't use `*`, and Starlette `allow_origins` is exact-match (no subdomain wildcards). The playground is served from the MDR UI, so `mdr.<env>.lif.unicon.net` is the only prod origin per env; `${PublicHostedZoneName}` resolves it per environment automatically.

`GET /demo/personas` (#1057) is on by default (`MDR__DEMO_ENDPOINTS_ENABLED` defaults `true`), so no MDR change is needed.

**Not in this PR:** the actual `aws-deploy` of the LDE (and MDR) services + the live verification — that's the ops remainder of #1076.

##### Related Issues

Refs #1076
Refs #1034
Refs #1000

##### Type of Change

- [x] Infrastructure / deployment config

##### Checklist

- [x] Self-reviewed the diff
- [x] Mirrors the proven `mdr-api` CORS + Cognito pattern (same SSM keys, same `${PublicHostedZoneName}`)
- [x] No application code changes; no new SSM parameters
- [ ] Verified live after deploy: MDR UI → Export Playground → pick persona + format → run → colorized result

🤖 Generated with [Claude Code](https://claude.com/claude-code)