### PR TITLE
Issue #1066: green ruff/format/ty across the tree (PR CI prep, 1/n)

### DIFF
--- a/components/lif/data_source_adapters/example_data_source_rest_api_to_lif_adapter/adapter.py
+++ b/components/lif/data_source_adapters/example_data_source_rest_api_to_lif_adapter/adapter.py
@@ -11,7 +11,7 @@ logger = get_logger(__name__)
 class ExampleDataSourceRestAPIToLIFAdapter(LIFDataSourceAdapter):
     """Adapter that gathers data from the Example Data Source REST API for LIF to use (no translation in the adapter)."""
 
-    adapter_id: str = "example-data-source-rest-api-to-lif"
+    adapter_id = "example-data-source-rest-api-to-lif"
     adapter_type = LIFAdapterType.PIPELINE_INTEGRATED
     credential_keys = ["host", "scheme", "token"]
 

--- a/components/lif/data_source_adapters/lif_to_lif_adapter/adapter.py
+++ b/components/lif/data_source_adapters/lif_to_lif_adapter/adapter.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 class LIFToLIFAdapter(LIFDataSourceAdapter):
     """Adapter that converts LIF data to LIF data (no-op)."""
 
-    adapter_id: str = "lif-to-lif"
+    adapter_id = "lif-to-lif"
     adapter_type = LIFAdapterType.LIF_TO_LIF
     credential_keys = ["host", "scheme", "token"]
 

--- a/components/lif/identity_mapper_storage_sql/model.py
+++ b/components/lif/identity_mapper_storage_sql/model.py
@@ -28,7 +28,9 @@ class IdentityMappingModel(Base):
     )
 
     def from_identity_mapping(self, identity_mapping: IdentityMapping):
-        self.mapping_id = identity_mapping.mapping_id
+        # mapping_id is Optional on the DTO; when unset, let the column default (uuid4) generate it.
+        if identity_mapping.mapping_id is not None:
+            self.mapping_id = identity_mapping.mapping_id
         self.lif_organization_id = identity_mapping.lif_organization_id
         self.lif_organization_person_id = identity_mapping.lif_organization_person_id
         self.target_system_id = identity_mapping.target_system_id

--- a/integration_tests/test_01_mongodb.py
+++ b/integration_tests/test_01_mongodb.py
@@ -121,7 +121,7 @@ class TestMongoDBDataIntegrity:
                     results.append(result)
                 else:
                     # Create a failure result for missing person
-                    from utils.comparison import ComparisonResult, Difference
+                    from utils.comparison import Difference
 
                     results.append(
                         ComparisonResult(

--- a/integration_tests/utils/comparison.py
+++ b/integration_tests/utils/comparison.py
@@ -92,7 +92,7 @@ def _compare_values(
         return
 
     # Type mismatch
-    if type(expected) != type(actual):
+    if type(expected) is not type(actual):
         # Allow int/float comparison
         if isinstance(expected, (int, float)) and isinstance(actual, (int, float)):
             if expected != actual:

--- a/test/components/lif/lif_schema_config/test_core.py
+++ b/test/components/lif/lif_schema_config/test_core.py
@@ -142,17 +142,17 @@ class TestTypeMappings:
     """Tests for XSD type mappings."""
 
     def test_xsd_to_python_mappings(self):
-        assert XSD_TO_PYTHON["xsd:string"] == str
-        assert XSD_TO_PYTHON["xsd:integer"] == int
-        assert XSD_TO_PYTHON["xsd:boolean"] == bool
-        assert XSD_TO_PYTHON["xsd:date"] == date
-        assert XSD_TO_PYTHON["xsd:dateTime"] == datetime
+        assert XSD_TO_PYTHON["xsd:string"] is str
+        assert XSD_TO_PYTHON["xsd:integer"] is int
+        assert XSD_TO_PYTHON["xsd:boolean"] is bool
+        assert XSD_TO_PYTHON["xsd:date"] is date
+        assert XSD_TO_PYTHON["xsd:dateTime"] is datetime
 
     def test_python_type_for_xsd(self):
-        assert python_type_for_xsd("xsd:string") == str
-        assert python_type_for_xsd("xsd:integer") == int
-        assert python_type_for_xsd("unknown_type") == str  # default
-        assert python_type_for_xsd("unknown_type", default=int) == int
+        assert python_type_for_xsd("xsd:string") is str
+        assert python_type_for_xsd("xsd:integer") is int
+        assert python_type_for_xsd("unknown_type") is str  # default
+        assert python_type_for_xsd("unknown_type", default=int) is int
 
     def test_xsd_type_for_python(self):
         assert xsd_type_for_python(str) == "xsd:string"

--- a/test/components/lif/mdr_auth/test_invite_token.py
+++ b/test/components/lif/mdr_auth/test_invite_token.py
@@ -86,11 +86,13 @@ class TestDecodeRejection:
         from base64 import urlsafe_b64encode
         from lif.mdr_auth.invite_token import _sign
 
-        for raw in (b'[1,2,3]', b'"just a string"', b'42', b'null'):
+        for raw in (b"[1,2,3]", b'"just a string"', b"42", b"null"):
             encoded = urlsafe_b64encode(raw).decode().rstrip("=")
             sig = _sign(encoded, SECRET)
             token = f"{encoded}.{sig}"
-            assert decode_invite_token(token, secret=SECRET) is None, f"non-object payload {raw!r} should decode to None"
+            assert decode_invite_token(token, secret=SECRET) is None, (
+                f"non-object payload {raw!r} should decode to None"
+            )
 
 
 class TestExpiryRecovery:


### PR DESCRIPTION
##### Description

First step toward a **required PR CI check (#1066)**. Introducing that check surfaced that the tree isn't repo-wide clean — `pre-commit` only lints *changed* files, so ruff/ty violations accumulated in files no one has touched since a rule landed. This PR brings **ruff, ruff-format, and ty** to green across the whole repo so the eventual CI gate can pass. **No behavior changes.**

Fixes:
- **ty `invalid-attribute-override` (×2):** drop the redundant `: str` re-annotation of `adapter_id` in the two adapters. The base declares `adapter_id: ClassVar[str]`; the subclasses now assign a plain value (like their sibling `adapter_type` / `credential_keys`), which is a valid ClassVar value override.
- **ty `invalid-assignment` (×1):** `IdentityMappingModel.from_identity_mapping` assigned `dto.mapping_id` (`str | None`) to `Mapped[str]`. Guarded on `is not None` — when the DTO omits it, the column's `uuid4` default generates it (identical result, now type-correct).
- **ruff E721 (×8):** type comparisons now use `is` / `is not` (`integration_tests/utils/comparison.py`, `test/.../lif_schema_config/test_core.py`).
- **ruff F823 (×1):** removed an in-function `from utils.comparison import ComparisonResult` that shadowed the module-level import (referenced-before-assignment).
- **ruff-format (×1):** reformatted `test_invite_token.py`.

##### Verification

Run against the full tree:
- `uv run ruff check` → **All checks passed**
- `uv run ruff format --check` → **351 files already formatted**
- `uv run ty check --error-on-warning` → **All checks passed**
- `uv run pytest test` → unchanged at **11 pre-existing failures / 652 passed** (the test failures are tracked separately as the next step; this PR neither fixes nor worsens them).

##### Related Issues

Refs #1066

<!-- Part 1 of the "full green, then require" rollout: (1) lint/format/type [this PR] → (2..n) fix the 11 test failures → (final) add the workflow + mark it required. -->

##### Type of Change

- [x] Chore / tooling (lint + type hygiene, no behavior change)

##### Checklist

- [x] Self-reviewed the diff
- [x] ruff / ruff-format / ty green across the tree
- [x] pytest unchanged (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)