### PR TITLE
Issue #756: fix inlined-ref detection dropping PascalCase embedded children (PR CI, 3/n)

### DIFF
--- a/components/lif/mdr_services/schema_upload_service.py
+++ b/components/lif/mdr_services/schema_upload_service.py
@@ -82,6 +82,12 @@ def is_inlined_reference(prop_name: str, prop) -> bool:
     """True if `prop` is an MDR inlined entity reference rather than an embedded child or attribute."""
     if not isinstance(prop, dict) or "$ref" in prop or "ValueSetId" in prop:
         return False
+    # The "Ref" marker must actually be present in the key. rpartition() returns the whole string
+    # as child_name when the separator is absent, so without this guard EVERY PascalCase embedded
+    # child entity (e.g. "Courses") is misread as a reference and dropped on re-upload (#756/#1007
+    # regression — LIF entity keys are PascalCase, so this silently emptied nested `properties`).
+    if REFERENCE_KEY_MARKER not in prop_name:
+        return False
     _, child_name = parse_reference_key(prop_name)
     # The marker must be followed by a PascalCase entity name; this keeps an embedded child whose
     # own name merely contains "Ref" (e.g. "Reference") from being misread as a reference.

--- a/test/components/lif/mdr_services/test_schema_upload_service.py
+++ b/test/components/lif/mdr_services/test_schema_upload_service.py
@@ -58,6 +58,10 @@ def test_parse_reference_key_has_relevant_relationship_name_is_lost():
         ("someAttr", {"ValueSetId": 1}, False),
         # no marker at all
         ("hasOrganization", {"type": "object", "properties": {}}, False),
+        # PascalCase embedded child with no "Ref" marker must NOT be read as a reference — every
+        # LIF entity key is PascalCase, so misreading this dropped all nested entities on re-upload
+        # (#1007 regression). The camelCase case above didn't catch it (it fails the PascalCase guard).
+        ("Courses", {"type": "object", "properties": {}}, False),
     ],
 )
 def test_is_inlined_reference(prop_name, prop, expected):


### PR DESCRIPTION
##### Description

Fixes a **production regression from #1007** (Issue #756) and clears the last cluster of pre-existing test failures blocking required PR CI (#1066).

**The bug (#1083):** #1007 added `is_inlined_reference()` to skip MDR *inlined entity references* on schema re-upload. It uses `prop_name.rpartition("Ref")`, which returns the **whole key** as `child_name` when `"Ref"` is absent. Any PascalCase property key with no `$ref`/`ValueSetId` therefore returned `True` and was skipped in `create_entity_and_children_if_needed` (`schema_upload_service.py:531`). **Every LIF entity key is PascalCase**, so re-uploading an MDR-exported schema silently dropped all nested child entities — exports came back with empty `properties`.

**The fix:** require the `"Ref"` marker to actually be present (`REFERENCE_KEY_MARKER in prop_name`) before treating a key as a reference. One-line guard; the reference-detection feature is otherwise unchanged.

**Test:** added a PascalCase-embedded-child case (`"Courses"` → `False`) to the `is_inlined_reference` parametrized test. #1007's existing "no marker" case used camelCase (`"hasOrganization"`), which fails the PascalCase guard regardless — so it never exercised this path.

##### How it was found

Bisected the 10 failing `test_transformation_endpoint.py` tests — all passed at `dabf6b9^` and failed at `dabf6b9` (#1007). Those tests upload a `Person → Courses → Grade` schema and read back the assembled `properties`; they'd been **red on `main` since #1007 merged**, but with no PR CI running the suite, it shipped. This is the concrete argument for #1066.

##### Verification

- `test_transformation_endpoint.py` → **10 passed** (were all failing)
- `test_schema_upload_service.py` + `test_schema_roundtrip.py` (#1007's own tests) → **still pass** (reference detection intact)
- Full `pytest test` on this branch → **1 failing** — and it's `test_create_attribute_ok`, fixed by #1082; nothing else
- `ruff check` clean; ty project gate unchanged (`mdr_services/` is ty-excluded)

##### Related Issues

Closes #1083
Refs #756
Refs #1066

<!-- Rollout: (1) lint/type #1081 → (2) attribute test #1082 → (3) THIS: transformation cluster / #1007 regression → with #1082 this greens pytest → (final) add workflow + require -->

##### Type of Change

- [x] Bug fix (production regression)

##### Checklist

- [x] Self-reviewed the diff
- [x] Root cause bisected to #1007; fix is minimal + targeted
- [x] Regression test added; #1007's feature tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)