### PR TITLE
Issue #1066: add PR-time CI workflow (MERGE LAST — final step)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,86 @@
+name: PR CI
+
+# Server-side gate on pull requests. Until now pre-commit was the only check and
+# the first CI run was a deploy from `main`; this mirrors the local pre-commit gate
+# (ruff / ty / pytest) plus a frontend build so regressions are caught pre-merge.
+# Issue #1066.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same PR.
+concurrency:
+  group: pr-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python (ruff / ty / pytest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv + Python 3.13
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.15"
+          python-version: "3.13"
+          enable-cache: true
+
+      # --frozen fails if uv.lock is stale, covering the uv-lock pre-commit hook.
+      - name: Install dependencies (locked)
+        run: uv sync --frozen
+
+      - name: Ruff lint
+        run: uv run ruff check
+
+      - name: Ruff format check
+        run: uv run ruff format --check
+
+      - name: Type check (ty)
+        run: uv run ty check --error-on-warning
+
+      - name: Tests
+        run: uv run pytest test
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [mdr-frontend, lif_advisor_app]
+    defaults:
+      run:
+        shell: bash
+        working-directory: frontends/${{ matrix.app }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontends/${{ matrix.app }}/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # mdr-frontend's build is `tsc -b && vite build`, so this also type-checks.
+      - name: Build
+        run: npm run build
+
+      # Runs vitest where a test script exists (lif_advisor_app); no-op otherwise.
+      - name: Unit tests
+        run: npm run test --if-present


### PR DESCRIPTION
##### Description

**Draft / merge-last.** Adds `.github/workflows/pr-ci.yml` — the actual PR-time CI gate for #1066. Runs the pre-commit checks server-side on every PR to `main`:

- **Python:** `uv sync --frozen` → `ruff check` → `ruff format --check` → `ty check --error-on-warning` → `pytest test`
- **Frontend:** node-20 `npm ci` + `npm run build` (tsc typechecks) + `npm run test --if-present`, matrixed over `mdr-frontend` and `lif_advisor_app`

##### ⚠️ Ordering — do not merge yet

This must merge **after** the green-the-tree chain, or its own run (and every other PR's) goes red:

1. [ ] #1081 — lint/format/type green
2. [ ] #1082 — attribute_service test
3. [ ] #1084 — #1007 nested-entity regression (bug #1083)
4. [ ] **then** rebase this on the now-green `main`, confirm the `PR CI` run is green
5. [ ] mark **`PR CI`** a **required status check** on `main` (branch-protection setting — admin, not in this file)

Kept as a **draft** until steps 1–3 land. Its own CI run will be red until then — by design (main isn't green yet).

##### Related Issues

Refs #1066

##### Type of Change

- [x] CI / tooling

##### Checklist

- [x] YAML validated
- [x] Mirrors the pre-commit gate (ruff / ruff-format / ty / pytest) + frontend build
- [ ] Rebased on green main + run confirmed green (post-chain)
- [ ] `PR CI` marked required in branch protection (post-merge, admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)