### PR TITLE
Issue #1068: collapse 11 per-service deploy workflows into one reusable workflow

### DIFF
--- a/.github/workflows/_deploy-service.yml
+++ b/.github/workflows/_deploy-service.yml
@@ -1,0 +1,109 @@
+name: Deploy service to ECS (reusable)
+
+# Reusable deploy pipeline for the Python API services (#1068). Each service's
+# workflow is a thin caller that supplies its paths trigger + these inputs; the
+# build/push/redeploy steps live here once instead of being copy-pasted per service.
+#
+# build-and-push builds the wheel image and pushes :latest to ECR; update-cluster
+# forces a new ECS deployment (no build artifact needed), so we build once and then
+# fan the ECS redeploys out over `ecs_services` in a matrix (covers the 3-org services).
+
+on:
+  workflow_call:
+    inputs:
+      service_name:
+        description: Short name used for STS session names (e.g. "mdr-api").
+        required: true
+        type: string
+      working_dir:
+        description: Project directory containing build.sh + Dockerfile.
+        required: true
+        type: string
+      ecr_repository:
+        description: ECR repository, e.g. "lif/dev/lif_mdr_api".
+        required: true
+        type: string
+      ecs_services:
+        description: JSON array of ECS service names to force-redeploy, e.g. '["mdr-api-FARGATE"]'.
+        required: true
+        type: string
+      ecs_cluster:
+        required: false
+        type: string
+        default: dev
+      aws_region:
+        required: false
+        type: string
+        default: us-east-1
+      gha_role:
+        required: false
+        type: string
+        default: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
+      free_disk_space:
+        description: Reclaim runner disk before building (needed by large images e.g. semantic-search).
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: Build & push image
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Free up disk space
+        if: ${{ inputs.free_disk_space }}
+        run: |
+          df -h
+          sudo rm -rf /usr/lib/jvm /usr/share/dotnet /usr/local/lib/android /usr/local/share/chromium /opt/microsoft /opt/google
+          docker system prune -af || true
+          df -h
+
+      - name: Build the project
+        working-directory: ${{ inputs.working_dir }}
+        run: |
+          curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
+          ./build.sh
+
+      - name: Build and push docker image
+        uses: ./.github/actions/build-and-push
+        with:
+          working-dir: ${{ inputs.working_dir }}
+          github-actions-role: ${{ inputs.gha_role }}
+          role-session-name: ${{ inputs.service_name }}-build
+          aws-region: ${{ inputs.aws_region }}
+          ecr-repository: ${{ inputs.ecr_repository }}
+
+  deploy:
+    name: Redeploy ECS service
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      # Redeploy each org's service independently; one failing org shouldn't block the others.
+      fail-fast: false
+      matrix:
+        ecs_service: ${{ fromJSON(inputs.ecs_services) }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update the ${{ matrix.ecs_service }} ECS service
+        uses: ./.github/actions/update-cluster
+        with:
+          github-actions-role: ${{ inputs.gha_role }}
+          role-session-name: ${{ inputs.service_name }}-ecs
+          aws-region: ${{ inputs.aws_region }}
+          ecs-cluster: ${{ inputs.ecs_cluster }}
+          ecs-service: ${{ matrix.ecs_service }}

--- a/.github/workflows/lif_advisor_api.yml
+++ b/.github/workflows/lif_advisor_api.yml
@@ -1,19 +1,9 @@
 name: Deploy LIF Advisor API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE: advisor-api-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_advisor_api.yml
       - bases/lif_advisor_restapi/**
@@ -23,43 +13,17 @@ on:
       - components/lif/lif_logging/**
       - components/lif/auth/**
       - projects/lif_advisor_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-advisor-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_advisor_api
-      ECR_REPOSITORY: lif/dev/lif_advisor_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: advisor-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-advisor-api ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: advisor-api-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: advisor-api
+      working_dir: ./projects/lif_advisor_api
+      ecr_repository: lif/dev/lif_advisor_api
+      ecs_services: '["advisor-api-FARGATE"]'

--- a/.github/workflows/lif_example_data_source_rest_api.yml
+++ b/.github/workflows/lif_example_data_source_rest_api.yml
@@ -1,19 +1,9 @@
 name: Deploy LIF Example Data Source REST API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE: example-data-source-rest-api-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_example_data_source_rest_api.yml
       - bases/lif/example_data_source_rest_api/**
@@ -23,43 +13,17 @@ on:
       - components/lif/logging/**
       - components/lif/auth/**
       - projects/lif_example_data_source_rest_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-example-data-source-rest-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_example_data_source_rest_api
-      ECR_REPOSITORY: lif/dev/lif_example_data_source_rest_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: example-data-source-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-example-data-source-rest-api ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: example-data-source-api-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: example-data-source
+      working_dir: ./projects/lif_example_data_source_rest_api
+      ecr_repository: lif/dev/lif_example_data_source_rest_api
+      ecs_services: '["example-data-source-rest-api-FARGATE"]'

--- a/.github/workflows/lif_graphql_api.yml
+++ b/.github/workflows/lif_graphql_api.yml
@@ -1,21 +1,9 @@
 name: Deploy LIF GraphQL API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE_ORG1: graphql-org1-FARGATE
-  ECS_SERVICE_ORG2: graphql-org2-FARGATE
-  ECS_SERVICE_ORG3: graphql-org3-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_graphql_api.yml
       - bases/lif/api_graphql/**
@@ -26,62 +14,17 @@ on:
       - components/lif/string_utils/**
       - components/lif/logging/**
       - projects/lif_graphql_api/**
+      - .github/workflows/_deploy-service.yml
 
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-graphql-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_graphql_api
-      ECR_REPOSITORY: lif/dev/lif_graphql_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: graphql-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the graphql-org1 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: graphql-org1-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}
-
-    - name: Update the graphql-org2 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: graphql-org2-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG2 }}
-
-    - name: Update the graphql-org3 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: graphql-org3-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG3 }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: graphql
+      working_dir: ./projects/lif_graphql_api
+      ecr_repository: lif/dev/lif_graphql_api
+      ecs_services: '["graphql-org1-FARGATE", "graphql-org2-FARGATE", "graphql-org3-FARGATE"]'

--- a/.github/workflows/lif_identity_mapper_api.yml
+++ b/.github/workflows/lif_identity_mapper_api.yml
@@ -1,21 +1,9 @@
 name: Deploy LIF Identity Mapper API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE_ORG1: identity-mapper-org1-FARGATE
-  ECS_SERVICE_ORG2: identity-mapper-org2-FARGATE
-  ECS_SERVICE_ORG3: identity-mapper-org3-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_identity_mapper_api.yml
       - bases/lif/identity_mapper_restapi/**
@@ -29,61 +17,17 @@ on:
       - components/lif/datatypes/**
       - components/lif/logging/**
       - projects/lif_identity_mapper_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-identity-mapper-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_identity_mapper_api
-      ECR_REPOSITORY: lif/dev/lif_identity_mapper_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: identity-mapper-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-identity-mapper-org1 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: identity-mapper-org1-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}
-
-    - name: Update the lif-identity-mapper-org2 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: identity-mapper-org2-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG2 }}
-
-    - name: Update the lif-identity-mapper-org3 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: identity-mapper-org3-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG3 }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: identity-mapper
+      working_dir: ./projects/lif_identity_mapper_api
+      ecr_repository: lif/dev/lif_identity_mapper_api
+      ecs_services: '["identity-mapper-org1-FARGATE", "identity-mapper-org2-FARGATE", "identity-mapper-org3-FARGATE"]'

--- a/.github/workflows/lif_learner_data_export_api.yml
+++ b/.github/workflows/lif_learner_data_export_api.yml
@@ -1,19 +1,9 @@
 name: Deploy LIF Learner Data Export API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE_ORG1: learner-data-export-api-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_learner_data_export_api.yml
       - bases/lif/learner_data_export_api/**
@@ -32,42 +22,17 @@ on:
       - components/lif/tenant_routing/**
       - components/lif/translator_client/**
       - projects/lif_learner_data_export_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-learner-data-export-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_learner_data_export_api
-      ECR_REPOSITORY: lif/dev/lif_learner_data_export_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: learner-data-export-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-learner-data-export-api ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: learner-data-export-api-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: learner-data-export-api
+      working_dir: ./projects/lif_learner_data_export_api
+      ecr_repository: lif/dev/lif_learner_data_export_api
+      ecs_services: '["learner-data-export-api-FARGATE"]'

--- a/.github/workflows/lif_mdr_api.yml
+++ b/.github/workflows/lif_mdr_api.yml
@@ -1,19 +1,9 @@
 name: Deploy LIF MDR API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE: mdr-api-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_mdr_api.yml
       - bases/lif/mdr_restapi/**
@@ -22,43 +12,17 @@ on:
       - components/lif/mdr_dto/**
       - components/lif/mdr_services/**
       - components/lif/mdr_utils/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  mdr-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_mdr_api
-      ECR_REPOSITORY: lif/dev/lif_mdr_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: mdr-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the MDR API ECS service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: mdr-api-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: mdr-api
+      working_dir: ./projects/lif_mdr_api
+      ecr_repository: lif/dev/lif_mdr_api
+      ecs_services: '["mdr-api-FARGATE"]'

--- a/.github/workflows/lif_orchestrator_api.yml
+++ b/.github/workflows/lif_orchestrator_api.yml
@@ -1,19 +1,9 @@
 name: Deploy LIF Orchestrator API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE: orchestrator-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_orchestrator_api.yml
       - bases/lif/orchestrator_restapi/**
@@ -25,43 +15,17 @@ on:
       - components/lif/orchestrator_clients/**
       - components/lif/orchestrator_service/**
       - projects/lif_orchestrator_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-orchestrator-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_orchestrator_api
-      ECR_REPOSITORY: lif/dev/lif_orchestrator
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: orchestrator-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-orchestrator-api ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: orchestrator-api-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: orchestrator
+      working_dir: ./projects/lif_orchestrator_api
+      ecr_repository: lif/dev/lif_orchestrator
+      ecs_services: '["orchestrator-FARGATE"]'

--- a/.github/workflows/lif_query_cache_api.yml
+++ b/.github/workflows/lif_query_cache_api.yml
@@ -1,21 +1,9 @@
 name: Deploy LIF Query Cache API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE_ORG1: query-cache-org1-FARGATE
-  ECS_SERVICE_ORG2: query-cache-org2-FARGATE
-  ECS_SERVICE_ORG3: query-cache-org3-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_query_cache_api.yml
       - bases/lif/query_cache_restapi/**
@@ -27,61 +15,17 @@ on:
       - components/lif/mongodb_connection/**
       - components/lif/exceptions/**
       - projects/lif_query_cache_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-query-cache-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_query_cache_api
-      ECR_REPOSITORY: lif/dev/lif_query_cache_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-cache-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the query-cache-org1 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-cache-org1-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}
-
-    - name: Update the query-cache-org2 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-cache-org2-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG2 }}
-
-    - name: Update the query-cache-org3 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-cache-org3-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG3 }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: query-cache
+      working_dir: ./projects/lif_query_cache_api
+      ecr_repository: lif/dev/lif_query_cache_api
+      ecs_services: '["query-cache-org1-FARGATE", "query-cache-org2-FARGATE", "query-cache-org3-FARGATE"]'

--- a/.github/workflows/lif_query_planner_api.yml
+++ b/.github/workflows/lif_query_planner_api.yml
@@ -1,21 +1,9 @@
 name: Deploy LIF Query Planner API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE_ORG1: query-planner-org1-FARGATE
-  ECS_SERVICE_ORG2: query-planner-org2-FARGATE
-  ECS_SERVICE_ORG3: query-planner-org3-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_query_planner_api.yml
       - bases/lif/query_planner_restapi/**
@@ -25,61 +13,17 @@ on:
       - components/lif/datatypes/**
       - components/lif/logging/**
       - projects/lif_query_planner_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-query-planner-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_query_planner_api
-      ECR_REPOSITORY: lif/dev/lif_query_planner_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-planner-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the query-planner-org1 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-planner-org1-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}
-
-    - name: Update the query-planner-org2 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-planner-org2-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG2 }}
-
-    - name: Update the query-planner-org3 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: query-planner-org3-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG3 }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: query-planner
+      working_dir: ./projects/lif_query_planner_api
+      ecr_repository: lif/dev/lif_query_planner_api
+      ecs_services: '["query-planner-org1-FARGATE", "query-planner-org2-FARGATE", "query-planner-org3-FARGATE"]'

--- a/.github/workflows/lif_semantic_search_mcp_server.yml
+++ b/.github/workflows/lif_semantic_search_mcp_server.yml
@@ -1,19 +1,9 @@
 name: Deploy LIF Semantic Search MCP Server to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE: semantic-search-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_semantic_search_mcp_server.yml
       - bases/lif/semantic_search_mcp_server/**
@@ -26,66 +16,18 @@ on:
       - components/lif/string_utils/**
       - components/lif/mdr_client/**
       - projects/lif_semantic_search_mcp_server/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-semantic-search-mcp-server:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_semantic_search_mcp_server
-      ECR_REPOSITORY: lif/dev/lif_semantic_search_mcp_server
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Remove unused tooling to free up disk space
-      run: |
-        df -h
-        
-        # Remove Java (JDKs)
-        sudo rm -rf /usr/lib/jvm
-
-        # Remove .NET SDKs
-        sudo rm -rf /usr/share/dotnet
-
-        # Remove Android SDKs
-        sudo rm -rf /usr/local/lib/android
-
-        # Remove Chromium
-        sudo rm -rf /usr/local/share/chromium
-
-        # Remove Microsoft/Edge and Google Chrome builds
-        sudo rm -rf /opt/microsoft /opt/google
-
-        docker system prune -af || true
-        
-        df -h
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: semantic-search-mcp-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-semantic-search-mcp-server ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: semantic-search-mcp-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: semantic-search-mcp
+      working_dir: ./projects/lif_semantic_search_mcp_server
+      ecr_repository: lif/dev/lif_semantic_search_mcp_server
+      ecs_services: '["semantic-search-FARGATE"]'
+      free_disk_space: true

--- a/.github/workflows/lif_translator_api.yml
+++ b/.github/workflows/lif_translator_api.yml
@@ -1,88 +1,30 @@
 name: Deploy LIF Translator API to Amazon ECS
 
-env:
-  AWS_REGION: us-east-1
-  GHA_ROLE: "arn:aws:iam::381492161417:role/lif-github-actions-dev"
-  ECS_CLUSTER: dev
-  ECS_SERVICE_ORG1: translator-org1-FARGATE
-  # ECS_SERVICE_ORG1: translator-org2-FARGATE
-  # ECS_SERVICE_ORG1: translator-org3-FARGATE
-
-permissions:
-      id-token: write
-      contents: read
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - .github/workflows/lif_translator_api.yml
       - bases/lif/translator_restapi/**
       - cloudformation/dev-lif-translator-org1.params
-      # - cloudformation/dev-lif-translator-org2.params
-      # - cloudformation/dev-lif-translator-org3.params
       - cloudformation/lif-translator-taskdef-includes.yml
       - components/lif/exceptions/**
       - components/lif/logging/**
       - components/lif/mdr_client/**
       - components/lif/translator/**
       - projects/lif_translator_api/**
+      - .github/workflows/_deploy-service.yml
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-
-  lif-translator-api:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    env:
-      WORKING_DIR: ./projects/lif_translator_api
-      ECR_REPOSITORY: lif/dev/lif_translator_api
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Build the project
-      shell: bash
-      working-directory: ${{ env.WORKING_DIR }}
-      run: |
-        curl -LsSf https://astral.sh/uv/0.7.15/install.sh | sh
-        ./build.sh
-
-    - name: Build and push docker image
-      uses: ./.github/actions/build-and-push
-      with:
-        working-dir: ${{ env.WORKING_DIR }}
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: translator-api-build
-        aws-region: ${{ env.AWS_REGION }}
-        ecr-repository: ${{ env.ECR_REPOSITORY }}
-
-    - name: Update the lif-translator-org1 ECS Service
-      uses: ./.github/actions/update-cluster
-      with:
-        github-actions-role: ${{ env.GHA_ROLE }}
-        role-session-name: translator-org1-ecs
-        aws-region: ${{ env.AWS_REGION }}
-        ecs-cluster: ${{ env.ECS_CLUSTER }}
-        ecs-service: ${{ env.ECS_SERVICE_ORG1 }}
-#
-#     - name: Update the lif-translator-org2 ECS Service
-#       uses: ./.github/actions/update-cluster
-#       with:
-#         github-actions-role: ${{ env.GHA_ROLE }}
-#         role-session-name: translator-org2-ecs
-#         aws-region: ${{ env.AWS_REGION }}
-#         ecs-cluster: ${{ env.ECS_CLUSTER }}
-#         ecs-service: ${{ env.ECS_SERVICE_ORG2 }}
-#
-#     - name: Update the lif-translator-org3 ECS Service
-#       uses: ./.github/actions/update-cluster
-#       with:
-#         github-actions-role: ${{ env.GHA_ROLE }}
-#         role-session-name: translator-org3-ecs
-#         aws-region: ${{ env.AWS_REGION }}
-#         ecs-cluster: ${{ env.ECS_CLUSTER }}
-#         ecs-service: ${{ env.ECS_SERVICE_ORG3 }}
-
+  deploy:
+    uses: ./.github/workflows/_deploy-service.yml
+    with:
+      service_name: translator
+      working_dir: ./projects/lif_translator_api
+      ecr_repository: lif/dev/lif_translator_api
+      ecs_services: '["translator-org1-FARGATE"]'


### PR DESCRIPTION
##### Description

Third CF/CI item (#1068). The 11 Python-service deploy workflows each carried a ~40-line copy of the same build → push → ECS-redeploy job, which drifts independently. This extracts that into **one `on: workflow_call` reusable workflow** (`.github/workflows/_deploy-service.yml`); each service file becomes a **thin caller** that supplies only its `paths` trigger and a `with:` block.

**Reusable workflow**
- `build` job: checkout → optional disk cleanup → `build.sh` → `build-and-push`
- `deploy` job (`needs: build`): fans `update-cluster` out over `ecs_services` in a **matrix**, so the org1/2/3 services (graphql, identity-mapper, query-cache, query-planner) redeploy all their orgs from one build. `update-cluster` only forces an ECS redeploy (no build artifact), so splitting build/deploy is safe.
- Shared constants (`aws_region`, `gha_role`, `ecs_cluster`) default in the reusable workflow — callers don't repeat them.

**Callers**
- `paths` triggers preserved **exactly** (verified programmatically against `upstream/main`), plus each now also triggers on `_deploy-service.yml` so a change to the shared pipeline rebuilds all services.
- semantic-search keeps its disk-cleanup step via `free_disk_space: true`.

Net: **663 deletions / 252 insertions**, 12 files. YAML validated for all 12.

##### Verification

- All 12 workflow files parse as valid YAML.
- Every caller's `push.paths` == its original list + the reusable-workflow path (asserted in a script, no drift).
- Active ECS targets per service cross-checked against the originals (single vs org1/2/3; translator is org1-only, org2/3 were already commented out).

##### ⚠️ Needs a validation deploy before relying on it

GitHub Actions can't be run locally, so the reusable-workflow + `fromJSON` matrix + OIDC path hasn't been exercised end-to-end. **Before trusting it**, run a `workflow_dispatch` on one single-service (`mdr-api`) and one multi-org service (`graphql`) and confirm build+push+redeploy succeed. Path triggers are unchanged, so no service deploys differently until a matching path changes.

Frontends / dagster / mongodb workflows are intentionally out of scope (different build shape).

##### Related Issues

Closes #1068
Refs #1074

##### Type of Change

- [x] CI / infrastructure (no application code)

##### Checklist

- [x] Self-reviewed the diff (explicit staging; only the 12 intended files)
- [x] Paths preserved exactly + YAML validated
- [ ] `workflow_dispatch` validation deploy (single + multi-org) — before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
