### PR TITLE
Issue #1070: verify ECS deploys reach steady state before passing

### DIFF
--- a/.github/actions/update-cluster/action.yml
+++ b/.github/actions/update-cluster/action.yml
@@ -16,6 +16,10 @@ inputs:
   ecs-service:
     description: The target ECS Service
     required: true
+  verify-steady-state:
+    description: Wait for the forced deployment to reach ECS steady state and fail if it doesn't (#1070).
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -35,7 +39,7 @@ runs:
         verbose: false
         arch: amd64
 
-    - name: Force ECS service deployment
+    - name: Force ECS service deployment and verify steady state
       id: vars
       shell: bash
       run: |
@@ -60,3 +64,34 @@ runs:
             --cluster  ${{ inputs.ecs-cluster }} \
             --service ${{ inputs.ecs-service }} \
             --force-new-deployment
+
+        # --- Post-deploy verification (#1070) ---------------------------------------------
+        # Without this the action returns as soon as the deployment is *requested*; a bad image
+        # (crash loop / failing health checks) would deploy silently and run degraded. Wait for
+        # the service to reach steady state and fail the pipeline if it doesn't.
+        if [ "${{ inputs.verify-steady-state }}" != "true" ]; then
+          echo "verify-steady-state disabled; skipping post-deploy stability check"
+          exit 0
+        fi
+
+        echo "Waiting for \"${{ inputs.ecs-service }}\" to reach steady state (aws ecs wait services-stable, ~10 min max)..."
+        if ! aws ecs wait services-stable \
+            --cluster ${{ inputs.ecs-cluster }} \
+            --service ${{ inputs.ecs-service }}; then
+          echo "::error::\"${{ inputs.ecs-service }}\" did not reach steady state — the new deployment failed to stabilize (bad image, failing health checks, or insufficient capacity)."
+          aws ecs describe-services --cluster ${{ inputs.ecs-cluster }} --service ${{ inputs.ecs-service }} \
+            --query 'services[0].deployments[].{status:status,rollout:rolloutState,desired:desiredCount,running:runningCount,failed:failedTasks}' --output table || true
+          aws ecs describe-services --cluster ${{ inputs.ecs-cluster }} --service ${{ inputs.ecs-service }} \
+            --query 'services[0].events[:8].message' --output table || true
+          exit 1
+        fi
+
+        # A service with the deployment circuit breaker can reach steady state by ROLLING BACK to
+        # the previous task definition; that is a failed deploy, not a success — catch it.
+        rollout=$(aws ecs describe-services --cluster ${{ inputs.ecs-cluster }} --service ${{ inputs.ecs-service }} \
+          --query 'services[0].deployments[?status==`PRIMARY`].rolloutState | [0]' --output text)
+        if [ "$rollout" = "FAILED" ]; then
+          echo "::error::deployment rolled back (rolloutState=FAILED) — the new image never became healthy."
+          exit 1
+        fi
+        echo "✅ \"${{ inputs.ecs-service }}\" reached steady state (rolloutState=$rollout)"


### PR DESCRIPTION
##### Description

CF/CI item #1070. The `update-cluster` composite action returned as soon as `force-new-deployment` was *requested* — a bad image (crash loop, failing health checks) would deploy silently and run degraded while the pipeline reported green. This adds post-deploy verification.

- **`aws ecs wait services-stable`** after the forced deployment; on timeout it dumps the deployment rollout state + recent service events and **fails the step** (`exit 1`).
- **Rollback detection:** a service with the deployment circuit breaker can reach steady state by *rolling back* to the old task def — that's a failed deploy. After stabilizing, the action checks the PRIMARY deployment's `rolloutState` and fails on `FAILED`.
- Gated by a new **`verify-steady-state`** input (default `"true"`) as an escape hatch; **no caller changes needed**.

It lives in the **shared composite action**, so both the current per-service workflows *and* the #1068 reusable workflow gain the check automatically — independent of whether #1068 merges.

##### Verification

- `action.yml` parses as valid YAML (new input present).
- The embedded deploy script passes `bash -n`.

##### ⚠️ Needs a real deploy to confirm behavior

GitHub Actions / AWS can't run locally, so the wait + rollout-state logic hasn't executed end-to-end. Validate on a real deploy (a good one → passes; ideally also observe a deliberately-bad image → fails). Two knobs may need tuning:
- `aws ecs wait services-stable` defaults to ~10 min (40 × 15s); a slow-starting service could false-fail — the `verify-steady-state` input allows opting out per-call if needed.

##### Related Issues

Closes #1070
Refs #1074

##### Type of Change

- [x] CI / infrastructure (no application code)

##### Checklist

- [x] Self-reviewed the diff
- [x] YAML + `bash -n` validated
- [ ] Confirmed on a real deploy (good + bad image) — before relying on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
