### PR TITLE
docs: clarify leaf-Closes / epic-Refs issue linkage (PR template + open-pr skill)

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -9,7 +9,7 @@ Open a pull request that passes review on the first read. The whole point of thi
 
 ## Arguments
 
-- `[issue number]` — the issue this PR closes (becomes `Closes #N`). If omitted, infer from the branch name / commits and confirm with the user.
+- `[issue number]` — the leaf issue this PR fully resolves (becomes `Closes #N`; an epic gets `Refs #N` instead — see Related Issues in Step 3). If omitted, infer from the branch name / commits and confirm with the user.
 
 ## Step 1 — Read the conventions (do not skip)
 
@@ -35,7 +35,7 @@ Read all three now:
 Compose the body from the template — fill every section, **remove checklist items that don't apply** (the template says so):
 
 - **Description of Change** — what problem it solves, the solution, side effects/limitations, and **how reviewers should test it**. (The relay synthesis from `self-review-relay`, if you ran it, is good source material.)
-- **Related Issues** — `Closes #<n>` (this is what auto-closes the issue on merge).
+- **Related Issues** — `Closes #<leaf>` for the issue this PR **fully resolves**: merging auto-closes it *and* auto-moves its card to Done on Project #6. For an **epic / umbrella** issue, use `Refs #<epic>` (never `Closes` — it must stay open so its sub-issue rollup tracks progress). So a PR implementing one item of an epic reads `Closes #<leaf>` / `Refs #<epic>`. Using `Refs` on the leaf leaves the issue open and stranded mid-board after merge.
 - **Type of Change** — check the one(s) that apply (bug fix / feature / breaking / docs / infra / perf / refactor).
 - **Project Area(s) Affected** — check by the actual diff (`git diff main...HEAD --name-only` → map to `bases/`, `components/`, `frontends/`, `cloudformation/`, migrations, etc.).
 - **Checklist** — check the items truly done (lint/format/type/pre-commit; tests included; docs updated; migration + CHANGELOG if schema changed; MIGRATION.md if breaking). Remove the rest.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,9 +17,14 @@ Include:
 -->
 
 ##### Related Issues
-<!-- Auto-close the issue this PR resolves. The number must come directly after `#` (no space, no brackets)
-     or GitHub will NOT auto-close on merge — e.g. `Closes #123`. Use `Refs #123` for related-but-not-closed
-     issues. Delete this line if the PR closes nothing. -->
+<!-- Link the issue(s) this PR relates to. The number must come directly after `#` — no space, no
+     brackets — or GitHub won't parse it (e.g. `Closes #123`, not `Closes # 123`).
+       - `Closes #123` — a leaf issue this PR FULLY resolves. Merging auto-closes it AND moves its
+                         card to Done on the project board. Use one per issue you actually finished.
+       - `Refs #123`   — a related issue this PR does NOT fully resolve, OR an epic / umbrella issue
+                         (which must stay open — its sub-issue rollup tracks progress, so never `Closes` it).
+     Example for a PR implementing one item of an epic:  `Closes #123`  /  `Refs #120` (the epic).
+     Delete these lines if the PR closes nothing. -->
 
 Closes #
 


### PR DESCRIPTION
##### Description of Change

Contributors (and the `open-pr` skill) were using `Refs #N` on leaf issues a PR fully resolved — so merging didn't auto-close them, and their project-board cards never moved to Done. Hit this on #1067/#1068/#1070 (their PRs #1086/#1087/#1088 said `Refs` and had to be corrected to `Closes`).

Codifies the rule so it doesn't recur:
- **`Closes #<leaf>`** — an issue this PR *fully resolves*: merging auto-closes it **and** auto-moves its card to Done on the board.
- **`Refs #<epic>`** — a related or umbrella/epic issue that must stay open (its sub-issue rollup tracks progress) — never `Closes`.

Changes:
- `.github/pull_request_template.md` — expanded the Related Issues guidance with the leaf-vs-epic distinction + a worked example.
- `.claude/skills/open-pr/SKILL.md` — updated the input hint and the Step 3 "Related Issues" instruction to match.

Docs/tooling only; no code paths touched.

##### Related Issues

Refs #1068

<!-- Refs the CF/CI epic (#1074 area) rather than Closes — this is process doc, not an epic item. -->

##### Type of Change

- [x] Documentation update

##### Project Area(s) Affected

- [x] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)

##### Checklist

- [x] commit message follows commit guidelines
- [x] documentation is changed or added

🤖 Generated with [Claude Code](https://claude.com/claude-code)