### PR TITLE
fix: deploy actions read aws-region input (unbreaks all service deploys)

### DIFF
--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -30,7 +30,7 @@ runs:
         audience: sts.amazonaws.com
         role-to-assume: ${{ inputs.github-actions-role }}
         role-session-name: ${{ inputs.role-session-name }}
-        aws-region: ${{ env.AWS_REGION }}
+        aws-region: ${{ inputs.aws-region }}
 
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/actions/update-cluster/action.yml
+++ b/.github/actions/update-cluster/action.yml
@@ -30,7 +30,7 @@ runs:
         audience: sts.amazonaws.com
         role-to-assume: ${{ inputs.github-actions-role }}
         role-session-name: ${{ inputs.role-session-name }}
-        aws-region: ${{ env.AWS_REGION }}
+        aws-region: ${{ inputs.aws-region }}
 
     - id: install-aws-cli
       uses: unfor19/install-aws-cli-action@v1


### PR DESCRIPTION
##### Description of Change

**Hotfix.** After #1068's reusable deploy workflow merged, **every service deploy failed** at the first step — `Configure AWS credentials` → `Input required and not supplied: aws-region`.

Root cause: `build-and-push` and `update-cluster` both declare an `aws-region` **input** but the credential step read `${{ env.AWS_REGION }}` instead of the input. The old per-service workflows set `env: AWS_REGION` at the workflow level, masking it. The new reusable workflow (`_deploy-service.yml`) passes region as an **input** and doesn't set that env → the credential step got an empty region.

**No production impact:** the failure was at credential config, before build/push; the redeploy step was `skipped`, so no service was actually redeployed — running services are untouched.

Fix: both actions now read `${{ inputs.aws-region }}`. Verified all 7 workflows that call these actions already pass the `aws-region` input, so this is safe everywhere and makes the declared input actually work.

##### Related Issues

Refs #1068

##### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure/deployment change

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates
<!-- GitHub Actions composite actions -->

##### Checklist

- [x] commit message follows commit guidelines
- [x] YAML validated

##### Testing

- [x] Will validate on merge: re-run a service deploy (LDE) via `workflow_dispatch` and confirm it reaches build + ECS steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)