### PR TITLE
fix: grant GHA deploy role ecs:DescribeServices (steady-state check)

### DIFF
--- a/cloudformation/repositories.yml
+++ b/cloudformation/repositories.yml
@@ -226,6 +226,9 @@ Resources:
         - Effect: Allow
           Action:
             - 'ecs:UpdateService'
+            # DescribeServices is required by the post-deploy `aws ecs wait services-stable`
+            # steady-state check (#1070) in the update-cluster action.
+            - 'ecs:DescribeServices'
           Resource:
             - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/${EnvironmentName}*'
         - Effect: Allow


### PR DESCRIPTION
##### Description of Change

The #1070 post-deploy steady-state check (`aws ecs wait services-stable`, added to the `update-cluster` action) calls **`ecs:DescribeServices`**, but the `lif-github-actions-<env>` role only had `ecs:UpdateService` + `ecs:List*`. So after that check went live, **every service deploy fails at the verify step** with `AccessDeniedException` on `DescribeServices` (surfaced on the first real deploy — LDE).

Adds `ecs:DescribeServices`, scoped to `service/${EnvironmentName}*` (same as `UpdateService`).

**Note:** the deploy itself is unaffected — `force-new-deployment` succeeds; only the steady-state *verification* is blocked. And this permission takes effect **only after the repositories/IAM stack is redeployed** — until that ops step runs, deploys still fail at verify.

##### Related Issues

Refs #1070

##### Type of Change

- [x] Infrastructure/deployment change
- [x] Bug fix (non-breaking change which fixes an issue)

##### Project Area(s) Affected

- [x] cloudformation/ or sam/ templates

##### Checklist

- [x] commit message follows commit guidelines

##### Additional Notes

Follow-up ops: redeploy the `repositories` stack (`dev`, then `demo`) to apply the IAM change, then re-run a service deploy to confirm the steady-state check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)