### PR TITLE
Issue #1093: harden cognito_auth so the missing-pyjwt[crypto] footgun can't recur

### DIFF
--- a/components/lif/cognito_auth/README.md
+++ b/components/lif/cognito_auth/README.md
@@ -31,3 +31,11 @@ enabled, the LDE base composes a *composite* inbound middleware that accepts a
 the JWT strategy and the developer-key validator (signed-token offline verify,
 #1033/#1038, ADR 0002) as the other. The composite lives at the base (composition
 is a base concern); this brick just provides the Cognito strategy.
+
+## Requirements
+
+**Consumers MUST depend on `pyjwt[crypto]`, not plain `pyjwt`.** Cognito tokens are
+RS256, which needs the `cryptography` backend. With plain `pyjwt`, verification raises
+`PyJWTError` that `authenticate_request` swallows → every token silently 401s (this was
+#1093 on LDE). The brick now guards against it: enabling Cognito (`is_enabled`) without
+`cryptography` raises a `RuntimeError` at startup instead of failing silently.

--- a/components/lif/cognito_auth/core.py
+++ b/components/lif/cognito_auth/core.py
@@ -17,19 +17,39 @@ Public surface:
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import jwt
+import jwt.algorithms  # ensure the submodule is imported for `jwt.algorithms.has_crypto`
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 _BEARER_PREFIX = "Bearer "
 
 # Cache PyJWKClient per (region, pool) so JWKS keys are fetched once per process.
 _jwk_clients: dict[tuple[str, str], jwt.PyJWKClient] = {}
+
+
+def _require_crypto() -> None:
+    """Fail loudly at startup if pyjwt lacks the crypto backend for RS256 (see #1093).
+
+    Cognito tokens are RS256; without `cryptography` (the ``pyjwt[crypto]`` extra) every
+    ``jwt.decode`` raises ``PyJWTError``, which ``authenticate_request`` swallows → every
+    token silently 401s. Any service composing this brick MUST depend on ``pyjwt[crypto]``;
+    this converts that footgun into an obvious boot-time error instead of a silent reject.
+    """
+    if not jwt.algorithms.has_crypto:
+        raise RuntimeError(
+            "cognito_auth requires the 'cryptography' package for RS256 JWT verification. "
+            "Depend on `pyjwt[crypto]` (plain `pyjwt` ships without it and silently rejects "
+            "every Cognito token). See #1093."
+        )
 
 
 @dataclass
@@ -63,11 +83,14 @@ class CognitoAuthConfig:
         ``api_key_auth`` "no keys → disabled" pattern), so a bare deployment
         runs without Cognito.
         """
-        return cls(
+        config = cls(
             user_pool_id=os.environ.get(f"{prefix}__USER_POOL_ID", ""),
             region=os.environ.get(f"{prefix}__REGION", "us-east-1"),
             client_id=os.environ.get(f"{prefix}__CLIENT_ID", ""),
         )
+        if config.is_enabled:
+            _require_crypto()
+        return config
 
 
 def _get_jwk_client(config: CognitoAuthConfig) -> jwt.PyJWKClient:
@@ -121,7 +144,8 @@ def authenticate_request(request: Request, config: CognitoAuthConfig) -> Optiona
         return None
     try:
         return decode_cognito_jwt(token, config)
-    except jwt.PyJWTError:
+    except jwt.PyJWTError as exc:
+        logger.warning("Cognito JWT rejected: %s", exc)
         return None
 
 
@@ -134,6 +158,8 @@ class CognitoAuthMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app, config: CognitoAuthConfig) -> None:
         super().__init__(app)
+        if config.is_enabled:
+            _require_crypto()
         self.config = config
 
     def _is_public(self, path: str) -> bool:

--- a/test/components/lif/cognito_auth/test_core.py
+++ b/test/components/lif/cognito_auth/test_core.py
@@ -1,5 +1,6 @@
 # cspell:disable
 import jwt
+import pytest
 from starlette.requests import Request
 
 import lif.cognito_auth.core as core
@@ -49,3 +50,19 @@ def test_authenticate_returns_none_for_invalid_token(monkeypatch):
 
     monkeypatch.setattr(core, "decode_cognito_jwt", boom)
     assert authenticate_request(_req("Bearer bad.token"), cfg) is None
+
+
+def test_enabled_config_requires_crypto(monkeypatch):
+    # A service enabling Cognito without pyjwt[crypto] must fail LOUDLY at startup,
+    # not silently 401 every token (the #1093 footgun).
+    monkeypatch.setenv("LDE_AUTH__USER_POOL_ID", "us-east-1_ABC123")
+    monkeypatch.setattr(jwt.algorithms, "has_crypto", False)
+    with pytest.raises(RuntimeError, match=r"pyjwt\[crypto\]"):
+        CognitoAuthConfig.from_environment(prefix="LDE_AUTH")
+
+
+def test_crypto_not_required_when_disabled(monkeypatch):
+    # A bare deployment (no pool) never verifies a Cognito token, so the guard must not fire.
+    monkeypatch.delenv("LDE_AUTH__USER_POOL_ID", raising=False)
+    monkeypatch.setattr(jwt.algorithms, "has_crypto", False)
+    assert not CognitoAuthConfig.from_environment(prefix="LDE_AUTH").is_enabled


### PR DESCRIPTION
##### Description of Change

#1093 (LDE 401ing every Cognito token) was so hard to spot because it failed **silently**: the LDE image lacked `cryptography` (plain `pyjwt`), so RS256 `jwt.decode` raised `PyJWTError`, which `authenticate_request` swallowed (`return None`) with no log. This makes the trap impossible to reship:

- **Startup guard** — `_require_crypto()` raises a clear `RuntimeError` when Cognito is enabled but `jwt.algorithms.has_crypto` is `False`. Called from `CognitoAuthConfig.from_environment` and `CognitoAuthMiddleware.__init__` (only when `is_enabled`), so a new consumer without `pyjwt[crypto]` fails **loudly at boot** instead of silently 401ing. Bare deployments (no pool) are unaffected.
- **Diagnosability** — `authenticate_request` now logs the rejection reason (previously swallowed). A future auth failure (expiry, `aud` mismatch, bad signature) shows up in the logs immediately.
- **Docs** — README states consumers MUST use `pyjwt[crypto]`.
- **Tests** — enabled config without crypto raises; disabled config never checks.

Only consumer today is LDE (already on `pyjwt[crypto]` via #1093), so the guard breaks nothing running.

##### Related Issues

Refs #1093
Refs #1034

##### Type of Change

- [x] Bug fix (hardening / prevent regression)

##### Project Area(s) Affected

- [x] components/
- [x] test/ or e2e/

##### Checklist

- [x] ruff / ruff-format / ty clean; 7 cognito_auth tests pass (incl. 2 new guard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)