### PR TITLE
feat(e2e): periodic happy-path monitors for both UIs (scheduled against demo)

### DIFF
--- a/.github/workflows/synthetic-e2e.yml
+++ b/.github/workflows/synthetic-e2e.yml
@@ -1,0 +1,85 @@
+name: Synthetic E2E monitor (demo)
+
+# Periodic happy-path checks through both UIs against demo, so an outage is caught here
+# instead of waiting for someone to report it. Runs the committed e2e/ Playwright suite:
+#   - Advisor: login → chat → assistant responds (exercises advisor → MCP → GraphQL → QP)
+#   - MDR:     Cognito login → Export Playground → run export (exercises MDR + LDE + composite auth)
+# A failed run turns the workflow red (the alert). Uses the dedicated e2e accounts; passwords
+# are read from SSM at run time via the demo OIDC role (never stored in the repo).
+
+on:
+  schedule:
+    - cron: "17 */4 * * *" # every 4 hours (offset off the top of the hour)
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  GHA_ROLE: arn:aws:iam::381492161417:role/lif-github-actions-demo
+
+jobs:
+  monitor:
+    name: Happy-path monitor (demo)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: e2e
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install dependencies + Chromium
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          audience: sts.amazonaws.com
+          role-to-assume: ${{ env.GHA_ROLE }}
+          role-session-name: synthetic-e2e
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Load e2e credentials from SSM (masked)
+        run: |
+          adv=$(aws ssm get-parameter --name /demo/advisor-api/DemoUserPassword --with-decryption --query Parameter.Value --output text)
+          mdr=$(aws ssm get-parameter --name /demo/e2e/mdr-playwright-pw --with-decryption --query Parameter.Value --output text)
+          echo "::add-mask::$adv"
+          echo "::add-mask::$mdr"
+          echo "ADVISOR_PASSWORD=$adv" >> "$GITHUB_ENV"
+          echo "MDR_PASSWORD=$mdr" >> "$GITHUB_ENV"
+
+      - name: Advisor happy path
+        env:
+          BASE_URL: https://advisor.demo.lif.unicon.net/
+          E2E_USERNAME: atsatrian_lifdemo@stateu.edu
+          E2E_PASSWORD: ${{ env.ADVISOR_PASSWORD }}
+        run: npx playwright test --grep @chat
+
+      - name: MDR happy path
+        if: always() # run even if the advisor check failed, so we see the status of both
+        env:
+          BASE_URL: https://mdr.demo.lif.unicon.net/
+          MDR_USERNAME: lif-e2e-test@unicon.net
+          MDR_PASSWORD: ${{ env.MDR_PASSWORD }}
+        run: npx playwright test --grep @happy-path
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -39,4 +39,25 @@ npm run test                                    # run all tests
 npx playwright test --grep @mdr                 # run only MDR tests
 npx playwright test --grep @cognito             # run only Cognito-specific tests
 npx playwright test --grep "@mdr and @legacy"   # run only MDR legacy login tests
+npx playwright test --grep @happy-path          # run only the happy-path monitors
 ```
+
+## Synthetic monitoring (periodic, against a live env)
+
+The `@happy-path` tests are **outage monitors** — walk a real user flow end to end so a
+break is caught before someone reports it:
+
+- **Advisor** (`@chat`): login → chat → the assistant replies (exercises advisor → MCP →
+  GraphQL → Query Planner).
+- **MDR** (`@mdr @cognito @happy-path`): Cognito login → Export Playground → run an export →
+  a result renders (exercises MDR + LDE + the composite Cognito auth in one flow).
+
+They run periodically via **`.github/workflows/synthetic-e2e.yml`** (every 4h + on demand)
+against **demo**, using dedicated e2e accounts whose passwords are read from SSM at run time
+(`/demo/advisor-api/DemoUserPassword`, `/demo/e2e/mdr-playwright-pw`) — never committed.
+MDR login here is **Cognito Hosted UI** (`MDR_USERNAME`/`MDR_PASSWORD` are the Cognito creds),
+not the legacy password form. The e2e Cognito user is `lif-e2e-test@unicon.net` (member of
+`lif-team`; provisioned on both the dev and demo pools).
+
+> The MDR Export-Playground monitor requires the LDE playground go-live to be deployed in the
+> target env (done on dev; on demo it passes once #1076 is promoted there).

--- a/e2e/fixtures/cognito-helpers.ts
+++ b/e2e/fixtures/cognito-helpers.ts
@@ -1,0 +1,34 @@
+import { Page } from "@playwright/test";
+
+/**
+ * The Cognito Hosted UI renders username/password/submit TWICE (desktop + mobile
+ * responsive sets); one is `display:none` and the first in DOM order is often the
+ * hidden one. So `.first().fill()` can silently no-op and waiting for `visible`
+ * can lock onto the hidden node. Act on the first *visible* match instead.
+ * (See docs/operations/guides/mdr-ui-e2e-playwright.md.)
+ */
+export async function fillVisible(page: Page, selector: string, value: string): Promise<void> {
+  const loc = page.locator(selector);
+  const count = await loc.count();
+  for (let i = 0; i < count; i++) {
+    const el = loc.nth(i);
+    if (await el.isVisible().catch(() => false)) {
+      await el.fill(value);
+      return;
+    }
+  }
+  throw new Error(`fillVisible: no visible element matched "${selector}"`);
+}
+
+export async function clickVisible(page: Page, selector: string): Promise<void> {
+  const loc = page.locator(selector);
+  const count = await loc.count();
+  for (let i = 0; i < count; i++) {
+    const el = loc.nth(i);
+    if (await el.isVisible().catch(() => false)) {
+      await el.click();
+      return;
+    }
+  }
+  throw new Error(`clickVisible: no visible element matched "${selector}"`);
+}

--- a/e2e/fixtures/mdr-export-playground-page.ts
+++ b/e2e/fixtures/mdr-export-playground-page.ts
@@ -1,0 +1,39 @@
+import { Locator, Page } from "@playwright/test";
+
+/**
+ * MDR UI "Export Playground" page — exercises the full LDE path end to end:
+ * personas (MDR /demo/personas) + formats (LDE /available-data-formats) + a run
+ * (LDE /exports). A good synthetic monitor: it touches MDR, LDE, and the composite
+ * Cognito auth in one flow.
+ */
+export class MdrExportPlaygroundPage {
+  readonly page: Page;
+  readonly heading: Locator;
+  readonly comboboxes: Locator; // [0] = Test learner, [1] = Output format (Radix selects)
+  readonly runButton: Locator;
+  readonly result: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: /Export Playground/i });
+    this.comboboxes = page.locator('[role="combobox"]');
+    this.runButton = page.getByRole('button', { name: /run export/i });
+    this.result = page.getByText(/Result/i).first();
+  }
+
+  async goto() {
+    await this.page.goto('/export-playground');
+  }
+
+  private async pickFirst(index: number) {
+    await this.comboboxes.nth(index).click();
+    await this.page.getByRole('option').first().click();
+  }
+
+  /** Pick the first learner + first format and run the export. */
+  async runFirstExport() {
+    await this.pickFirst(0); // learner (from MDR)
+    await this.pickFirst(1); // format (from LDE)
+    await this.runButton.click();
+  }
+}

--- a/e2e/fixtures/mdr-login-page.ts
+++ b/e2e/fixtures/mdr-login-page.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from "@playwright/test";
+import { fillVisible, clickVisible } from "./cognito-helpers";
 
 export class MdrLoginPage {
   readonly page: Page;
@@ -28,5 +29,25 @@ export class MdrLoginPage {
     await this.usernameField.fill(username);
     await this.passwordField.fill(password);
     await this.legacySubmitButton.click();
+  }
+
+  /**
+   * Cognito Hosted UI login (Authorization Code + PKCE) — the deployed dev/demo flow.
+   * Clicking Sign In redirects to the hosted UI; fill the visible (not the hidden
+   * responsive-duplicate) inputs, submit, and wait for the SPA callback to land back.
+   */
+  async loginWithCognito(username: string, password: string) {
+    const appHost = new URL(this.page.url()).host;
+    await this.signInButton.first().click();
+    await this.page.waitForSelector('input[name="password"], input[type="password"]', {
+      state: 'attached',
+      timeout: 30_000,
+    });
+    await this.page.waitForTimeout(1200);
+    await fillVisible(this.page, 'input[name="username"], input[type="email"], input[id*="signInFormUsername"]', username);
+    await fillVisible(this.page, 'input[type="password"], input[name="password"]', password);
+    await clickVisible(this.page, 'input[name="signInSubmitButton"], button[type="submit"], input[type="submit"]');
+    await this.page.waitForURL((url) => url.host === appHost, { timeout: 45_000 });
+    await this.page.waitForTimeout(2500);
   }
 }

--- a/e2e/tests/mdr-export-playground.spec.ts
+++ b/e2e/tests/mdr-export-playground.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { MdrLoginPage } from '../fixtures/mdr-login-page';
+import { MdrExportPlaygroundPage } from '../fixtures/mdr-export-playground-page';
+
+const SIXTY_SECONDS = 60 * 1000;
+
+/**
+ * MDR happy-path monitor: Cognito login → Export Playground → run an export → result.
+ * Exercises MDR (personas), LDE (formats + export), and the composite Cognito auth in
+ * one flow — the highest-signal single check that the deployed stack is actually working.
+ *
+ * Requires (Cognito hosted-UI login):
+ *   BASE_URL      — MDR frontend (e.g. https://mdr.demo.lif.unicon.net)
+ *   MDR_USERNAME  — Cognito user email
+ *   MDR_PASSWORD  — Cognito user password
+ */
+test.describe('MDR Export Playground (happy path)', { tag: ['@ui', '@mdr', '@cognito', '@happy-path'] }, () => {
+  test('cognito login → run export → result renders', async ({ page }) => {
+    const username = process.env.MDR_USERNAME;
+    const password = process.env.MDR_PASSWORD;
+    test.skip(!username || !password, 'MDR_USERNAME / MDR_PASSWORD must be set');
+    test.setTimeout(2 * SIXTY_SECONDS);
+
+    const login = new MdrLoginPage(page);
+    await login.goto();
+    await login.loginWithCognito(username!, password!);
+
+    const playground = new MdrExportPlaygroundPage(page);
+    await playground.goto();
+    await expect(playground.heading).toBeVisible({ timeout: 20_000 });
+
+    // Both selects must populate: learner (MDR /demo/personas) + format (LDE
+    // /available-data-formats). A disabled format select = LDE auth/reachability broke.
+    await expect(playground.comboboxes.nth(0)).toBeEnabled({ timeout: 30_000 });
+    await expect(playground.comboboxes.nth(1)).toBeEnabled({ timeout: 30_000 });
+    await expect(page.getByText(/could not load|unauthorized|failed to/i)).toHaveCount(0);
+
+    await playground.runFirstExport();
+
+    // The export chain (LDE → MDR → QP → Translator) renders a Result panel.
+    await expect(playground.result).toBeVisible({ timeout: SIXTY_SECONDS });
+  });
+});


### PR DESCRIPTION
##### Description of Change

Synthetic **outage monitors** — walk a real user's happy path through each UI end to end, on a schedule, so a break is caught before someone reports it (extends the committed `e2e/` Playwright suite).

- **MDR** (`@happy-path`): **Cognito** Hosted-UI login → Export Playground → run an export → result renders. One flow that exercises MDR (personas), LDE (formats + export), and the composite Cognito auth. Adds `MdrLoginPage.loginWithCognito()` (handles the hosted-UI duplicate-responsive-input gotcha via a `cognito-helpers` module) + an `MdrExportPlaygroundPage` POM.
- **Advisor** (`@chat`): the existing login → chat → assistant-replies spec, wired into the monitor.
- **`.github/workflows/synthetic-e2e.yml`**: runs every 4h + on demand, against **demo**, reading the dedicated e2e-account passwords from SSM at run time via the demo OIDC role (`/demo/advisor-api/DemoUserPassword`, `/demo/e2e/mdr-playwright-pw`) — nothing committed. Uploads the Playwright report on failure.

##### Verification

- **MDR `@happy-path` passes on dev** (17.5s) — Cognito login → export → result.
- **Advisor `@chat` passes on demo** (both tests, 53s).
- `tsc --noEmit` clean; `npm ci` works (lock in sync).

##### Notes

- MDR login here is **Cognito** (`MDR_USERNAME`/`MDR_PASSWORD` are the Cognito creds), not the legacy password form.
- The e2e Cognito user `lif-e2e-test@unicon.net` is provisioned on **both** the dev and demo pools (member of `lif-team`).
- ⚠️ The **MDR Export-Playground monitor turns green on demo only after the LDE playground go-live (#1076) is promoted there** (it's live on dev today). The advisor monitor works on demo now.

##### Related Issues

Refs #1076

##### Type of Change

- [x] New feature (e2e / tooling)

##### Project Area(s) Affected

- [x] test/ or e2e/

##### Checklist

- [x] Validated both monitors against a live env
- [x] Secrets sourced from SSM at run time (never committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)