### PR TITLE
Issue #1076: pin demo LDE to the pyjwt[crypto] image for playground go-live

### DIFF
--- a/cloudformation/demo-lif-learner-data-export-api.params
+++ b/cloudformation/demo-lif-learner-data-export-api.params
@@ -49,7 +49,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-07-08-23-34-57-190bb25"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_learner_data_export_api:2026-07-29-17-05-52-54e402c"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
Demo LDE was pinned to a **2026-07-08** image (pre-#1093) — no `cryptography`, so it 401s every Cognito token (the bug #1093 fixed on dev). Bumps the pin to the post-#1093 build `2026-07-29-17-05-52-54e402c` so demo LDE accepts the playground's Cognito JWT.

Part of promoting the LDE playground go-live to demo (demo MDR already has the CLR v2/OB3 mapping, so that format appears once the playground is live there).

Refs #1076 #1093

- [x] Infrastructure/deployment change

🤖 Generated with [Claude Code](https://claude.com/claude-code)