### PR TITLE
Issue #1076: pin demo mdr-api to the /demo/personas image for playground go-live

### DIFF
--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-07-08-23-34-54-190bb25"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-07-29-00-17-12-baf19a8"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
## What

Bump the **demo** `mdr-api` image pin from `2026-07-08-23-34-54-190bb25` to the current build `2026-07-29-00-17-12-baf19a8`.

## Why

The demo Export Playground failed with **"Could not load test learners"**: demo `mdr-api` was pinned to the 2026-07-08 image, which predates **#1057** (the `/demo/personas` endpoint). The personas fetch returned 404, so the test-learner picker stayed disabled and the export couldn't run. This is what a reviewer hit when checking the playground on demo — they also saw only 3 output formats, none being the CLR v2 / Open Badges v3 mapping (that gap was the stale demo LDE + frontend, already promoted in #1098/#1099).

`/demo/personas` returns static persona data (no schema dependency), so this is an image-only bump — no MDR migration required for the playground.

## Verification (post-deploy, against demo)

Deployed via `cfn-deploy.sh` (stack `demo-lif-mdr-api` → `UPDATE_COMPLETE`, task def `mdr-api-demo:11`). Then, end-to-end as `lif-e2e-test@unicon.net`:

- `GET /health-check` → 200
- `GET /demo/personas` → 401 without auth (endpoint now **exists**; was 404 on the old image)
- Playground: test-learner picker **enabled**, personas load, format picker enabled, **Run export returns valid JSON, no error**
- `GET /available-data-formats` → **5 formats incl. "CLR v2 - Open Badges v3"** (the mapping the reviewer couldn't find)

🤖 Generated with [Claude Code](https://claude.com/claude-code)