### PR TITLE
Issue #1089: alert on demo synthetic-monitor failure via SNS (email + SMS)

### DIFF
--- a/.github/workflows/synthetic-e2e.yml
+++ b/.github/workflows/synthetic-e2e.yml
@@ -83,3 +83,16 @@ jobs:
           name: playwright-report
           path: e2e/playwright-report/
           retention-days: 7
+
+      # Notify the team (email + SMS) when a happy-path check fails — this is the
+      # "alert" half of #1089. Topic + subscriptions live in repositories.yml; the
+      # demo OIDC role already assumed above has sns:Publish on the topic.
+      - name: Alert on failure (SNS)
+        if: failure()
+        working-directory: ${{ github.workspace }}
+        run: |
+          topic=$(aws ssm get-parameter --name /demo/alerts/TopicArn --query Parameter.Value --output text)
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          aws sns publish --topic-arn "$topic" \
+            --subject "LIF demo synthetic monitor FAILED" \
+            --message "The demo happy-path monitor failed (advisor and/or MDR/LDE). Investigate: ${run_url}"

--- a/cloudformation/demo-lif-repositories.params
+++ b/cloudformation/demo-lif-repositories.params
@@ -22,5 +22,9 @@
   {
     "ParameterKey": "AlertSmsNumber",
     "ParameterValue": "none"
+  },
+  {
+    "ParameterKey": "AlertAdditionalEmails",
+    "ParameterValue": "thelmick@unicon.net,khoyland@unicon.net,bgonzalez@unicon.net"
   }
 ]

--- a/cloudformation/demo-lif-repositories.params
+++ b/cloudformation/demo-lif-repositories.params
@@ -21,6 +21,6 @@
   },
   {
     "ParameterKey": "AlertSmsNumber",
-    "ParameterValue": "+12097772754"
+    "ParameterValue": "none"
   }
 ]

--- a/cloudformation/demo-lif-repositories.params
+++ b/cloudformation/demo-lif-repositories.params
@@ -14,5 +14,13 @@
   {
     "ParameterKey": "ExistingProviderArn",
     "ParameterValue": "arn:aws:iam::381492161417:oidc-provider/token.actions.githubusercontent.com"
+  },
+  {
+    "ParameterKey": "AlertEmail",
+    "ParameterValue": "bgonzalez@flex.unicon.net"
+  },
+  {
+    "ParameterKey": "AlertSmsNumber",
+    "ParameterValue": "+12097772754"
   }
 ]

--- a/cloudformation/repositories.yml
+++ b/cloudformation/repositories.yml
@@ -21,11 +21,27 @@ Parameters:
     Type: String
     Default: 'none'
 
+  AlertEmail:
+    Description: Email address subscribed to the ${EnvironmentName}-lif-alerts SNS topic (e.g. synthetic-monitor failures). Empty disables the email subscription.
+    Type: String
+    Default: ''
+
+  AlertSmsNumber:
+    Description: E.164 phone number subscribed to the alerts topic for SMS (e.g. +13135551234). 'none' disables SMS.
+    Type: String
+    Default: 'none'
+
 Conditions:
 
   CreateProvider: !Equals
     - !Ref ExistingProviderArn
     - 'none'
+
+  HasAlertEmail: !Not
+    - !Equals [!Ref AlertEmail, '']
+
+  HasAlertSms: !Not
+    - !Equals [!Ref AlertSmsNumber, 'none']
 
 Resources:
 
@@ -232,6 +248,13 @@ Resources:
           Resource:
             - !Sub 'arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/${EnvironmentName}*'
         - Effect: Allow
+          # Lets the synthetic-e2e monitor (#1095) publish an alert to the alerts
+          # topic when a demo happy-path check fails (#1089).
+          Action:
+            - 'sns:Publish'
+          Resource:
+            - !Ref AlertsTopic
+        - Effect: Allow
           Action:
             - ecr:GetAuthorizationToken
             - 'ecs:List*'
@@ -260,7 +283,43 @@ Resources:
         - Key: Name
           Value: !Sub lif-github-actions-${EnvironmentName}
 
+  # Operational alerts (e.g. synthetic-monitor failures, #1089). No Slack yet, so
+  # notifications go out over email + SMS. The topic ARN is published to SSM so
+  # workflows can look it up rather than hardcoding it.
+  AlertsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub ${EnvironmentName}-lif-alerts
+      DisplayName: LIFalerts
+
+  AlertsTopicArnParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /${EnvironmentName}/alerts/TopicArn
+      Type: String
+      Value: !Ref AlertsTopic
+
+  AlertsEmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasAlertEmail
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Ref AlertEmail
+
+  AlertsSmsSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasAlertSms
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: sms
+      Endpoint: !Ref AlertSmsNumber
+
 Outputs:
 
   GitHubOIDCProvider:
     Value: !If [CreateProvider, !Ref GitHubOIDCProvider, !Ref ExistingProviderArn]
+
+  AlertsTopicArn:
+    Description: ARN of the operational alerts SNS topic
+    Value: !Ref AlertsTopic

--- a/cloudformation/repositories.yml
+++ b/cloudformation/repositories.yml
@@ -31,6 +31,11 @@ Parameters:
     Type: String
     Default: 'none'
 
+  AlertAdditionalEmails:
+    Description: Comma-separated additional email addresses to subscribe to the alerts topic (up to 6), e.g. the rest of the dev team. Empty adds none.
+    Type: String
+    Default: ''
+
 Conditions:
 
   CreateProvider: !Equals
@@ -42,6 +47,18 @@ Conditions:
 
   HasAlertSms: !Not
     - !Equals [!Ref AlertSmsNumber, 'none']
+
+  # AlertAdditionalEmails is padded with trailing commas so !Select never runs
+  # off the end; a slot is subscribed only if its position holds a non-empty value.
+  # 8 slots — plenty of headroom to add more of the team over time.
+  HasAddlEmail0: !Not [!Equals [!Select [0, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail1: !Not [!Equals [!Select [1, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail2: !Not [!Equals [!Select [2, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail3: !Not [!Equals [!Select [3, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail4: !Not [!Equals [!Select [4, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail5: !Not [!Equals [!Select [5, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail6: !Not [!Equals [!Select [6, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
+  HasAddlEmail7: !Not [!Equals [!Select [7, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]], '']]
 
 Resources:
 
@@ -314,6 +331,71 @@ Resources:
       TopicArn: !Ref AlertsTopic
       Protocol: sms
       Endpoint: !Ref AlertSmsNumber
+
+  # Additional team email subscriptions, one per non-empty slot in AlertAdditionalEmails.
+  AddlEmailSub0:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail0
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [0, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub1:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail1
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [1, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub2:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail2
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [2, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub3:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail3
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [3, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub4:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail4
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [4, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub5:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail5
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [5, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub6:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail6
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [6, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
+
+  AddlEmailSub7:
+    Type: AWS::SNS::Subscription
+    Condition: HasAddlEmail7
+    Properties:
+      TopicArn: !Ref AlertsTopic
+      Protocol: email
+      Endpoint: !Select [7, !Split [",", !Sub "${AlertAdditionalEmails},,,,,,,"]]
 
 Outputs:
 


### PR DESCRIPTION
## What

Wires the demo synthetic-e2e monitor (#1095) to **notify the team on failure**, delivering the "alert" half of **#1089**. #1095 already runs the demo happy paths every 4 hours; until now a failure only turned the workflow red.

## Changes

- **`cloudformation/repositories.yml`**
  - New `${EnvironmentName}-lif-alerts` SNS topic + its ARN published to SSM `/${EnvironmentName}/alerts/TopicArn`.
  - Optional **email** + **SMS** subscriptions, gated on new `AlertEmail` / `AlertSmsNumber` params (default empty/`none`, so **dev stays silent** unless configured).
  - `sns:Publish` on the topic added to the existing GitHub Actions managed policy.
- **`cloudformation/demo-lif-repositories.params`** — subscribes the demo topic (email + SMS).
- **`.github/workflows/synthetic-e2e.yml`** — on `failure()`, look up the topic ARN from SSM and `aws sns publish` a message linking the failed run. Uses the demo OIDC role the job already assumes.

## Notes

- **No Slack yet** (chat migration next month) → alerts go over email + SMS.
- **SNS SMS sandbox:** if the account is still in the SMS sandbox, SMS only reaches *verified* numbers until production SMS access is requested — email works regardless. Called out so the SMS leg gets verified at deploy.
- Alerts fire each failing run (every 4h while broken); dedup/flap-suppression can be a follow-up if it's noisy.

## Verification plan (post-deploy)

1. Deploy `demo-lif-repositories`; confirm the email subscription + verify the SMS number.
2. Trigger a deliberately-failing `workflow_dispatch` run and confirm an email + SMS land with the run link.

Refs #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)