### PR TITLE
Issue #1089: strip adapter credential values (newline-tainted token broke demo advisor)

### DIFF
--- a/orchestrators/dagster/lif-orchestrator/src/lif_orchestrator/defs/lif_job.py
+++ b/orchestrators/dagster/lif-orchestrator/src/lif_orchestrator/defs/lif_job.py
@@ -55,7 +55,12 @@ def get_credentials_for_adapter(adapter_id: str, information_source_id: str) -> 
         env_var_name = f"{prefix}__{cred_key.upper()}"
         value = os.getenv(env_var_name)
         if value:
-            credentials[cred_key] = value
+            # Strip surrounding whitespace/newlines. Secrets sourced from SSM (or a
+            # file) commonly carry a trailing newline; passed verbatim into an HTTP
+            # header (e.g. the example-data-source adapter's "x-key": token) that
+            # newline is an illegal header value and requests/urllib3 raises
+            # InvalidHeader, failing the pipeline for that information source.
+            credentials[cred_key] = value.strip()
         else:
             warnings.warn(
                 f"Missing expected credential key '{cred_key}' for adapter '{adapter_id}' and source '{information_source_id}'"


### PR DESCRIPTION
## Root cause (demo outage 2026-07-30, caught by the #1095 synthetic monitor)

The demo advisor chat hung (typing indicator never cleared). All services were up — the failure was a **Dagster pipeline** error on a cache-miss data refresh:

```
run_lif_adapter failed after 2 retries for adapter_id=example-data-source-rest-api-to-lif
information_source_id=org1-example-data-source:
Invalid leading whitespace, reserved character(s), or return character(s) in header value:
'…-78a6b5c7d3ef\n'
```

`ExampleDataSourceRestAPIToLIFAdapter` passes its token straight into an HTTP header (`{"x-key": self.token}`, `example_data_source_rest_api_to_lif_adapter/adapter.py:25`). The token comes from SSM (`/demo/dagster-ose-example-data-source-rest-api-token`, per `cloudformation/dagster-ose-taskdef-includes.yml:45-47`) and carries a **trailing newline**. `urllib3` rejects a header value containing `\n` → `InvalidHeader` → the adapter fails after retries → the query never resolves → advisor retrieval blocks past the monitor's 60s bar → alert fired.

## Fix

Strip surrounding whitespace when loading adapter credentials in `get_credentials_for_adapter` (`orchestrators/dagster/lif-orchestrator/src/lif_orchestrator/defs/lif_job.py`). A newline on a secret sourced from SSM/a file is a common gotcha; stripping centrally protects **every** credential-based adapter, not just this token.

## Verification

- Demo CloudWatch traceback pinpoints the illegal `\n` header value (above).
- `.strip()` removes the trailing `\n` (the exact character `urllib3` rejects).
- (No unit test added: this orchestrator package's own modules aren't importable in its test venv — polylith packages only the `lif.*` bricks and Dagster loads `defs/` at runtime. A loader unit test is a follow-up once that's addressed.)

## Also needed to restore demo (separately)

The **SSM value itself still has the trailing newline** — this code makes it harmless, but until this deploys, correct `/demo/dagster-ose-example-data-source-rest-api-token` (strip the newline) and restart the Dagster services. See the issue/PR discussion.

Refs #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)