### PR TITLE
Issue #1103: recovery notifications + 2h cadence for the demo synthetic monitor

### DIFF
--- a/.github/workflows/synthetic-e2e.yml
+++ b/.github/workflows/synthetic-e2e.yml
@@ -9,12 +9,13 @@ name: Synthetic E2E monitor (demo)
 
 on:
   schedule:
-    - cron: "17 */4 * * *" # every 4 hours (offset off the top of the hour)
+    - cron: "17 */2 * * *" # every 2 hours (offset off the top of the hour)
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+  actions: read # recovery step queries the previous run's conclusion
 
 env:
   AWS_REGION: us-east-1
@@ -96,3 +97,23 @@ jobs:
           aws sns publish --topic-arn "$topic" \
             --subject "LIF demo synthetic monitor FAILED" \
             --message "The demo happy-path monitor failed (advisor and/or MDR/LDE). Investigate: ${run_url}"
+
+      # Send an "all clear" only when this success follows a prior failure, so a
+      # steady-green cadence stays silent but a recovery is announced (#1103).
+      - name: Notify on recovery (SNS)
+        if: success()
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Most-recent COMPLETED run excludes this still-running one, so it's the previous run.
+          prev=$(gh run list --repo "${GITHUB_REPOSITORY}" --workflow synthetic-e2e.yml \
+            --status completed --limit 1 --json conclusion --jq '.[0].conclusion // ""')
+          echo "previous completed run conclusion: ${prev:-<none>}"
+          if [ "$prev" = "failure" ]; then
+            topic=$(aws ssm get-parameter --name /demo/alerts/TopicArn --query Parameter.Value --output text)
+            run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            aws sns publish --topic-arn "$topic" \
+              --subject "LIF demo synthetic monitor RECOVERED" \
+              --message "The demo happy-path monitor is passing again after a prior failure. ${run_url}"
+          fi


### PR DESCRIPTION
Follow-ups to the demo alerting (#1089), tracked under #1103.

## Changes

- **Recovery ("all clear") notifications** — new `Notify on recovery (SNS)` step. On a successful run it checks the *previous* completed run's conclusion via `gh run list`; if that was `failure`, it publishes a **RECOVERED** message to `demo-lif-alerts`. Steady-green runs stay silent; only a genuine recovery is announced. Adds `actions: read` permission (needed to read the prior run's conclusion).
- **Cadence 4h → 2h** — faster detection of demo regressions (`cron: "17 */2 * * *"`).

## Behavior

| Transition | Notification |
|---|---|
| pass → fail | FAILED alert (existing) |
| fail → pass | **RECOVERED alert (new)** |
| pass → pass | silent |
| fail → fail | FAILED alert each run |

Delivered over the same email subscriptions as the failure alert (SMS still pending origination — see #1103).

Refs #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)