### PR TITLE
Issue #1119: enforce TLS 1.2+ on ALB + CloudFront (drop TLS 1.0/1.1)

### DIFF
--- a/cloudformation/s3-hosted.yml
+++ b/cloudformation/s3-hosted.yml
@@ -91,6 +91,10 @@ Resources:
         ViewerCertificate:
           AcmCertificateArn: !Ref SSLCertificate
           SslSupportMethod: sni-only
+          # Pin TLS 1.2+ for viewers. Without this, a custom-cert distribution
+          # defaults to MinimumProtocolVersion TLSv1, which permits TLS 1.0/1.1
+          # (encryption-policy violation flagged by cyber insurance, 2026-08).
+          MinimumProtocolVersion: TLSv1.2_2021
       Tags:
         - Key: Name
           Value: !Sub '${EnvironmentName}-${ServiceName}-cloudfront'

--- a/cloudformation/service-common.yml
+++ b/cloudformation/service-common.yml
@@ -488,9 +488,13 @@ Resources:
                 <a rel="home" title="404 Home" class="active" href="https://www.unicon.net/"><img class="logo" id="logo" alt="Unicon logo" title="Home" src="https://www.unicon.net/hs-fs/hubfs/raw_assets/public/Unicon_October2020/images/logo.png?width=600&name=logo.png"></a>		    
               </div>
       LoadBalancerArn: !Ref LoadBalancer
-      Port: 443 
+      Port: 443
       Protocol: HTTPS
-      Certificates: 
+      # Pin TLS 1.2+1.3 only. Without an explicit policy the listener defaults to
+      # ELBSecurityPolicy-2016-08, which still permits TLS 1.0/1.1 (encryption-policy
+      # violation flagged by cyber insurance, 2026-08).
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      Certificates:
         - CertificateArn: !Ref SSLCertificate
 
   SSLCertificate:


### PR DESCRIPTION
Remediates the cyber-insurance encryption-policy finding (TLS 1.0/1.1 on public LIF endpoints). Root cause: neither stack pinned a TLS floor, so both used permissive AWS defaults.

## Changes
- **`cloudformation/service-common.yml`** — shared 443 listener (`LoadBalancerHttpsListener`) now sets `SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06` (TLS 1.2+1.3 only). Was defaulting to `ELBSecurityPolicy-2016-08` (permits 1.0/1.1). Covers **advisor.demo / dev.lif / demo.lif** (dev + demo shared ALBs).
- **`cloudformation/s3-hosted.yml`** — CloudFront `ViewerCertificate` now sets `MinimumProtocolVersion: TLSv1.2_2021`. Was defaulting to `TLSv1`. Covers **mdr.dev** and any frontend built from this template.

## Scope note
`lif.unicon.net` (apex) does **not** resolve to this account — likely corporate `unicon.net` DNS, out of scope here; confirm with the insurer.

## Rollout (no downtime)
Redeploy the affected stacks: `dev-lif-common` + `demo-lif-common` (ALB listener update is instant), and each frontend's `s3-hosted` stack (CloudFront ~minutes to propagate).

## Verify after deploy
- SSL Labs (ssllabs.com/ssltest) on each domain → no TLS 1.0/1.1, or
- `aws elbv2 describe-listeners --query 'Listeners[?Port==\`443\`].SslPolicy'` and `aws cloudfront get-distribution-config` → `MinimumProtocolVersion`.

Deploy is on shared dev+demo infra — opening for review/merge rather than deploying unprompted.

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)