### PR TITLE
Issue #1121: make s3-hosted StackSet IAM roles reusable across envs (Phase 1)

### DIFF
--- a/cloudformation/s3-hosted-stackset.yml
+++ b/cloudformation/s3-hosted-stackset.yml
@@ -26,9 +26,24 @@ Parameters:
     Description: S3 key for the s3-hosted.yml template
     Default: cloudformation/s3-hosted.yml
 
+  CreateStackSetRoles:
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'true'
+    Description: >
+      Whether to create the account-global self-managed StackSet IAM roles
+      (AWSCloudFormationStackSet{Administration,Execution}Role). These names are
+      shared per-account, so exactly one env's frontend stack should create them
+      (true); every other env must reference the existing roles (false), or the
+      second stack fails with "...Role already exists".
+
+Conditions:
+  ShouldCreateStackSetRoles: !Equals [!Ref CreateStackSetRoles, 'true']
+
 Resources:
   StackSetAdministrationRole:
     Type: AWS::IAM::Role
+    Condition: ShouldCreateStackSetRoles
     Properties:
       RoleName: AWSCloudFormationStackSetAdministrationRole
       AssumeRolePolicyDocument:
@@ -49,6 +64,7 @@ Resources:
 
   StackSetExecutionRole:
     Type: AWS::IAM::Role
+    Condition: ShouldCreateStackSetRoles
     Properties:
       RoleName: AWSCloudFormationStackSetExecutionRole
       AssumeRolePolicyDocument:
@@ -78,13 +94,15 @@ Resources:
 
   S3HostedStackSet:
     Type: AWS::CloudFormation::StackSet
-    DependsOn:
-      - StackSetAdministrationRole
-      - StackSetExecutionRole
+    # No explicit DependsOn: when the roles are created here, the !GetAtt in
+    # AdministrationRoleARN is an implicit dependency; when reused, they already exist.
     Properties:
       StackSetName: !Sub '${EnvironmentName}-${ServiceName}-s3-hosted-stackset'
       Description: StackSet for S3 website hosting with CloudFront
-      AdministrationRoleARN: !GetAtt StackSetAdministrationRole.Arn
+      AdministrationRoleARN: !If
+        - ShouldCreateStackSetRoles
+        - !GetAtt StackSetAdministrationRole.Arn
+        - !Sub 'arn:aws:iam::${AWS::AccountId}:role/AWSCloudFormationStackSetAdministrationRole'
       ExecutionRoleName: AWSCloudFormationStackSetExecutionRole
       Capabilities:
         - CAPABILITY_NAMED_IAM
@@ -112,9 +130,11 @@ Outputs:
     Value: !Ref S3HostedStackSet
   
   StackSetAdministrationRoleArn:
+    Condition: ShouldCreateStackSetRoles
     Description: ARN of the StackSet administration role
     Value: !GetAtt StackSetAdministrationRole.Arn
-  
+
   StackSetExecutionRoleArn:
+    Condition: ShouldCreateStackSetRoles
     Description: ARN of the StackSet execution role
     Value: !GetAtt StackSetExecutionRole.Arn


### PR DESCRIPTION
Phase 1 of repairing the broken demo MDR frontend (#1121).

## Problem
`s3-hosted-stackset.yml` created the **account-global** self-managed StackSet roles (`AWSCloudFormationStackSet{Administration,Execution}Role`) unconditionally. Those names are one-per-account, so the second env to deploy collides — which is exactly why `demo-lif-mdr-frontend` rolled back (`...Role already exists in stack dev-lif-mdr-frontend`).

## Change
Add a `CreateStackSetRoles` parameter (default `true`, backward-compatible):
- The env that owns the shared roles (dev) keeps `true` → creates them.
- Other envs pass `false` → the StackSet references the existing roles by ARN instead of recreating them.

Roles + the two role Outputs are now conditional; the StackSet's `AdministrationRoleARN` uses `!If` to pick the created role vs. the existing ARN. `dev-lif-mdr-frontend` is unaffected (default keeps creating the roles).

## Not in this PR (Phase 2 — needs a plan/sign-off)
The demo cutover itself: migrating demo's existing live distro/bucket/cert/DNS from the direct-model stack into a stackset instance. Because the `mdr.demo` alias/distro already exist, that step risks a brief maintenance window or needs a resource import — tracked in #1121.

Refs #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)