### PR TITLE
Issue #1123: fix API-key creation (refresh-after-commit loses tenant search_path)

### DIFF
--- a/components/lif/mdr_services/developer_api_key_service.py
+++ b/components/lif/mdr_services/developer_api_key_service.py
@@ -40,11 +40,17 @@ async def create_developer_api_key(
     raw, key_prefix, key_hash = _generate_key()
     key = DeveloperApiKey(OwnerSub=owner_sub, Label=data.Label, KeyPrefix=key_prefix, KeyHash=key_hash)
     session.add(key)
-    await session.commit()
-    await session.refresh(key)
-    return CreatedDeveloperApiKeyDTO(
+    # Flush (INSERT ... RETURNING) populates Id/CreationDate while the request's
+    # tenant search_path is still active, and read them BEFORE commit. A refresh()
+    # after commit runs in a fresh transaction that has lost the tenant search_path,
+    # so it looks in `public`, can't find the tenant-schema row, and raises
+    # "Could not refresh instance".
+    await session.flush()
+    created = CreatedDeveloperApiKeyDTO(
         Id=key.Id, Label=key.Label, KeyPrefix=key.KeyPrefix, CreationDate=key.CreationDate, Key=raw
     )
+    await session.commit()
+    return created
 
 
 async def list_developer_api_keys(session: AsyncSession, owner_sub: str) -> List[DeveloperApiKeyDTO]:


### PR DESCRIPTION
## Bug
`POST /api-keys/` 500s in **dev and demo** with `sqlalchemy.exc.InvalidRequestError: Could not refresh instance`. The `DeveloperApiKeys` table exists (V1.5 migration applied; list/SELECT works) — this is a separate code bug.

## Root cause
`create_developer_api_key` did `add → commit() → refresh()`. Developer keys live in the **tenant schema** (request-time `search_path`). The `refresh()` after `commit()` runs in a fresh transaction that's lost that search_path → looks in `public` → tenant-schema row not found → error.

## Fix
`flush()` (runs `INSERT ... RETURNING`, populating `Id`/`CreationDate` while the search_path is active) → build the response from the flushed object → `commit()`. No post-commit reload.

## Verification
Smoke-test blocked API-key creation on dev + demo; this removes the failing reload. Post-deploy, re-test create on both envs.

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)