### PR TITLE
Issue #1123: pin demo mdr-api to the boto3 + api-key-fix build

### DIFF
--- a/cloudformation/demo-lif-mdr-api.params
+++ b/cloudformation/demo-lif-mdr-api.params
@@ -65,7 +65,7 @@
   },
   {
     "ParameterKey": "ImageUrl",
-    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-07-29-00-17-12-baf19a8"
+    "ParameterValue": "381492161417.dkr.ecr.us-east-1.amazonaws.com/lif/dev/lif_mdr_api:2026-08-05-03-49-52-b3c72b2"
   },
   {
     "ParameterKey": "TaskDefIncludesFile",


### PR DESCRIPTION
Promotes the dev-validated mdr-api image `2026-08-05-03-49-52-b3c72b2` (boto3 lockfile fix #1125 + api-key create fix #1124) to demo. Deployed + verified: clean startup (no boto3 crash), `/health-check` 200, running the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)