### PR TITLE
Issue #678: remove leftover exception classes from initial buildout

### DIFF
--- a/components/lif/exceptions/core.py
+++ b/components/lif/exceptions/core.py
@@ -48,19 +48,3 @@ class ResourceNotFoundException(LIFException):
     def __init__(self, resource_id, message=None):
         self.resource_id = resource_id
         super().__init__(message if message else f"Resource with ID '{resource_id}' not found.")
-
-
-class IllegalTriggerStateError(Exception):
-    pass
-
-
-class MissingSftpConfigurationError(Exception):
-    pass
-
-
-class MissingTriggerError(Exception):
-    pass
-
-
-class ScheduleNotFoundError(Exception):
-    pass


### PR DESCRIPTION
##### Description of Change

**Problem.** `components/lif/exceptions/core.py` ended with four exception classes that
don't belong to LIF:

- `IllegalTriggerStateError`
- `MissingSftpConfigurationError`
- `MissingTriggerError`
- `ScheduleNotFoundError`

**Solution.** Delete them. All four are empty (`pass`) declarations, and `git grep` finds
**zero references** anywhere in the repository outside their own definitions:

```
IllegalTriggerStateError         0
MissingSftpConfigurationError    0
MissingTriggerError              0
ScheduleNotFoundError            0
```

Pure dead-code removal, 16 lines, no functional change. LIF's own exception hierarchy in
the same file (`LIFException` and its subclasses) is untouched.

**Side effects / limitations.** None. Because nothing imports these names, no behavior can
change and no downstream service needs a corresponding update. 

**How to review.** Confirm the diff only removes the four class definitions, and
optionally re-run the grep above to verify nothing referenced them.

##### Related Issues

Refs #678

##### Type of Change

- [x] Code refactoring

##### Project Area(s) Affected

- [x] components/

---

##### Checklist

- [x] commit message follows commit guidelines (see commitlint.config.mjs)
- [x] code passes linting checks (`uv run ruff check`)
- [x] code passes formatting checks (`uv run ruff format`)
- [x] code passes type checking (`uv run ty check`)
- [x] pre-commit hooks have been run successfully

##### Testing

- [x] Automated tests added/updated — n/a; no tests referenced the removed classes, and
      none are warranted for a deletion of unused declarations.

Verification run locally on the branch:

| Gate | Result |
| --- | --- |
| `uv run ruff check` | All checks passed |
| `uv run ruff format --check` | 1 file already formatted |
| `uv run ty check` (full repo) | All checks passed |
| `uv run pytest test/` | **667 passed** |
| `uv run pre-commit run --files components/lif/exceptions/core.py` | all hooks Passed |


