### PR TITLE
Issue #956: Disable SQLAlchemy echo in MDR API (env-driven)

### DIFF
--- a/components/lif/mdr_utils/database_setup.py
+++ b/components/lif/mdr_utils/database_setup.py
@@ -49,8 +49,11 @@ def _redact_url(url: str) -> str:
 
 DATABASE_URL = f"postgresql+asyncpg://{os.getenv('POSTGRESQL_USER')}:{os.getenv('POSTGRESQL_PASSWORD')}@{os.getenv('POSTGRESQL_HOST')}:{os.getenv('POSTGRESQL_PORT')}/{os.getenv('POSTGRESQL_DB')}"
 logger.info("DATABASE_URL : %s", _redact_url(DATABASE_URL))
+# SQLAlchemy echo emits every SQL statement + bound parameters at INFO
+# level (#956). Dev-only debugging aid — keep off in deployed envs.
+SQLALCHEMY_ECHO = os.getenv("SQLALCHEMY_ECHO", "false").lower() == "true"
 # Create an async engine
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(DATABASE_URL, echo=SQLALCHEMY_ECHO)
 
 # Create an async sessionmaker
 # ty-ignore: Legacy sessionmaker(class_=AsyncSession); async_sessionmaker is the modern API.

--- a/cspell.json
+++ b/cspell.json
@@ -221,6 +221,7 @@
         "spyproject",
         "sqlmodel",
         "sqls",
+        "SQLALCHEMY",
         "stateu",
         "Starlette",
         "Streamable",

--- a/deployments/advisor-demo-docker/docker-compose.yml
+++ b/deployments/advisor-demo-docker/docker-compose.yml
@@ -494,6 +494,7 @@ services:
       POSTGRESQL_HOST: ${LIF_MDR__API__DATABASE_HOST:-lif-mdr-database}
       POSTGRESQL_PORT: ${LIF_MDR__API__DATABASE_PORT:-5432}
       POSTGRESQL_DB: ${LIF_MDR__API__DATABASE_DBNAME:-LIF}
+      SQLALCHEMY_ECHO: ${SQLALCHEMY_ECHO:-false}
       CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://localhost:3000,http://localhost:5173,http://localhost:8080,https://mdr.lif.unicon.net,https://mdr.demo.lif.unicon.net/}
       CORS_ALLOW_CREDENTIALS: ${CORS_ALLOW_CREDENTIALS:-true}
       CORS_ALLOW_METHODS: ${CORS_ALLOW_METHODS:-GET,POST,PUT,DELETE,OPTIONS,PATCH}

--- a/projects/lif_mdr_api/README.md
+++ b/projects/lif_mdr_api/README.md
@@ -29,6 +29,7 @@ All settings come from environment variables, parsed by `Settings` in `component
 | Env var | Purpose |
 |---|---|
 | `POSTGRESQL_*` | Database connection |
+| `SQLALCHEMY_ECHO` | `true` logs every SQL statement + bound params (dev-only; default `false`, read by `database_setup.py`) |
 | `MDR__AUTH__JWT_SECRET_KEY` | Signs HS256 access/refresh JWTs + workspace cookies + invite tokens |
 | `MDR__AUTH__SERVICE_API_KEY__*` | One key per internal service caller (graphql, semantic_search, translator, post_confirm, learner_data_export) |
 | `MDR__AUTH__COGNITO_*` | User pool id, region, SPA client id; empty user pool disables Cognito |

--- a/projects/lif_mdr_api/mdr-api.env.example
+++ b/projects/lif_mdr_api/mdr-api.env.example
@@ -4,6 +4,11 @@ POSTGRESQL_HOST=host.docker.internal
 POSTGRESQL_PORT=5445
 POSTGRESQL_DB=LIF
 
+# SQLAlchemy echo: logs every SQL statement and its bound parameters at INFO
+# level. Keep `false` (default) — only flip to `true` when debugging DB access
+# locally (issue #956).
+SQLALCHEMY_ECHO=false
+
 # CORS Configuration
 # Comma-separated list of allowed origins (use * for all origins)
 # Examples:

--- a/test/bases/lif/mdr_restapi/conftest.py
+++ b/test/bases/lif/mdr_restapi/conftest.py
@@ -83,7 +83,8 @@ async def test_db_session(postgres_server):
         f"postgresql+asyncpg://{parsed.username}:{parsed.password or ''}@{parsed.hostname}:{parsed.port}{parsed.path}"
     )
 
-    engine = create_async_engine(DATABASE_URL, echo=True)
+    echo = os.getenv("SQLALCHEMY_ECHO", "false").lower() == "true"
+    engine = create_async_engine(DATABASE_URL, echo=echo)
     async_session_maker = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session_maker() as session:

--- a/test/components/lif/mdr_utils/test_database_setup.py
+++ b/test/components/lif/mdr_utils/test_database_setup.py
@@ -8,6 +8,7 @@ The `get_session` tests patch `async_session`, so no real connection is made."""
 
 # cspell:ignore mydb dbhost cret unparseable agen sw0rd
 
+import importlib
 import types
 from unittest.mock import AsyncMock, MagicMock
 
@@ -56,6 +57,30 @@ class TestRedactUrl:
         # documents the "no exception" guarantee.
         assert _redact_url("") == ""
         assert _redact_url("not-a-url") == "not-a-url"
+
+
+class TestEchoToggle:
+    """#956 — SQLAlchemy echo must default to off and only come on via an
+    explicit `SQLALCHEMY_ECHO=true`. The engine is built at module import,
+    so reload the module under each env condition and inspect `engine.echo`."""
+
+    @staticmethod
+    def _reload(monkeypatch, value=None, *, unset=False):
+        if unset:
+            monkeypatch.delenv("SQLALCHEMY_ECHO", raising=False)
+        else:
+            monkeypatch.setenv("SQLALCHEMY_ECHO", value)
+        return importlib.reload(database_setup).engine.echo
+
+    def test_echo_off_by_default(self, monkeypatch):
+        assert self._reload(monkeypatch, unset=True) is False
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "True"])
+    def test_echo_on_when_env_is_true(self, monkeypatch, value):
+        assert self._reload(monkeypatch, value) is True
+
+    def test_echo_off_for_any_other_value(self, monkeypatch):
+        assert self._reload(monkeypatch, "1") is False
 
 
 def _make_request(tenant_schema):


### PR DESCRIPTION

Include:
- This is a fix for Issue #956. The default behavior for SQLAlchemy going forward will be for the echo to be set to "False". However, it is possible to turn the echo to True if that would be preferred in development environments.


##### Related Issues

Closes #956 


##### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/deployment change
- [X] Performance improvement
- [ ] Code refactoring

##### Project Area(s) Affected

- [ ] bases/
- [X] components/
- [ ] projects/
- [ ] orchestrators/
- [ ] frontends/
- [X] deployments/
- [ ] cloudformation/ or sam/ templates
- [ ] reference_data/
- [ ] scripts/
- [ ] test/ or e2e/
- [X] Database schema (migrations)
- [ ] API endpoints
- [ ] Documentation (docs/, READMEs, ARCHITECTURE.md, CLAUDE.md)


##### Checklist

- [X] commit message follows commit guidelines (see commitlint.config.mjs)
- [X ] code passes linting checks (`uv run ruff check`)
- [X] code passes formatting checks (`uv run ruff format`)
- [X] code passes type checking (`uv run ty check`)
- [X] pre-commit hooks have been run successfully
- [X] configuration changes: relevant folder README updated

##### Testing

- [X] Manual testing performed
- [ ] Automated tests added/updated
- [X] Integration testing completed

##### Additional Notes
Configuration updates done with the help of LLM. Did a complete deploy locally with docker to assure that the data was working.